### PR TITLE
feat: add custom Go linter with no-double-dash rule

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/lint/go.mod
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ videos/
 changelog/
 
 node_modules/
+
+# lint compiled binary
+tools/lint/lint

--- a/docs/admin/users/overview.mdx
+++ b/docs/admin/users/overview.mdx
@@ -79,6 +79,6 @@ As such, there are three possible statuses for a user:
 | `suspended` | User's access was revoked by an admin          |
 | `left`      | User has left the workspace                    |
 
-Only `active` users can log in and access workspace resources. `suspended` and `left` users exist solely for auditing purposes--they cannot log in to the workspace or access any resources.
+Only `active` users can log in and access workspace resources. `suspended` and `left` users exist solely for auditing purposes—they cannot log in to the workspace or access any resources.
 
 Users who have been suspended or left can be reinvited to the workspace at any time by an admin via [invites](/docs/admin/users/invites#send-an-invite).

--- a/docs/changelogs/agent.mdx
+++ b/docs/changelogs/agent.mdx
@@ -18,7 +18,7 @@ description: "Changelog and migration steps for the Miru Agent"
 
 ## Features
 
-- Deployments are guaranteed to be atomic--all config instances for a deployment are written to the filesystem simultaneously or none of them are
+- Deployments are guaranteed to be atomic—all config instances for a deployment are written to the filesystem simultaneously or none of them are
 - The agent now explicitly tracks `deployed_at` and `archived_at` timestamps on device when deployments are applied
 - Config instances deployed to the device's file system are now identical (indents, spacing, etc.) to config instances edited in the config editor
 

--- a/docs/developers/agent/architecture.mdx
+++ b/docs/developers/agent/architecture.mdx
@@ -33,7 +33,7 @@ The agent maintains a persistent connection to an MQTT broker over TLS. The cont
 
 ## Sync cycle
 
-At its core, the agent is built around a **sync** cycle--the process of reconciling the device's local state with the control plane's state.
+At its core, the agent is built around a **sync** cycle—the process of reconciling the device's local state with the control plane's state.
 
 When the agent performs a sync cycle, it communicates directly with the Miru control plane over HTTPS. MQTT is not used at all in this process.
 

--- a/docs/developers/agent/commands.mdx
+++ b/docs/developers/agent/commands.mdx
@@ -124,7 +124,7 @@ systemctl restart miru
 
 ### Stop
 
-`stop` stops the agent while leaving its state intact. Stopping the agent does not [disable](/docs/developers/agent/commands#disable) the agent--it will still automatically start on next system boot.
+`stop` stops the agent while leaving its state intact. Stopping the agent does not [disable](/docs/developers/agent/commands#disable) the agent—it will still automatically start on next system boot.
 
 Note that stopping the agent will prevent any new deployments from reaching the device until the agent is started again.
 
@@ -153,7 +153,7 @@ systemctl start miru
 
 Disabling the agent prevents it from starting automatically on boot. 
 
-This does not immediately [stop](/docs/developers/agent/commands#stop) the agent--it will still run if it is currently running. However, it will not be able to start on next system boot.
+This does not immediately [stop](/docs/developers/agent/commands#stop) the agent—it will still run if it is currently running. However, it will not be able to start on next system boot.
 
 ```bash
 systemctl disable miru
@@ -163,7 +163,7 @@ systemctl disable miru
 
 Enabling the agent allows it to start automatically on boot. This is the default behavior after installation and only needs to be done if the agent has been [disabled](/docs/developers/agent/commands#disable).
 
-Enabling the agent will not immediately start it--it will still need to be [started](/docs/developers/agent/commands#start) manually.
+Enabling the agent will not immediately start it—it will still need to be [started](/docs/developers/agent/commands#start) manually.
 
 ```bash
 systemctl enable miru

--- a/docs/developers/agent/security.mdx
+++ b/docs/developers/agent/security.mdx
@@ -143,7 +143,7 @@ The only local interface is a Unix domain socket at `/run/miru/miru.sock`, used 
 
 ## Local API access control
 
-The agent's local REST API is exposed through a Unix domain socket, not a TCP port. It is not possible to access the agent's local API over a network--it is only accessible from processes running on the same device as the agent.
+The agent's local REST API is exposed through a Unix domain socket, not a TCP port. It is not possible to access the agent's local API over a network—it is only accessible from processes running on the same device as the agent.
 
 Access is controlled through filesystem permissions:
 

--- a/docs/developers/agent/versions.mdx
+++ b/docs/developers/agent/versions.mdx
@@ -8,7 +8,7 @@ import { CardNewTab } from '/snippets/components/card.jsx';
 
 The Miru Agent follows [semantic versioning](https://semver.org/) for its releases. 
 
-Currently, the Miru Agent is still in beta, signified by the `v0` prefix for its releases. There is no established release cadence for the Miru Agent--features are simply released as soon as they are ready.
+Currently, the Miru Agent is still in beta, signified by the `v0` prefix for its releases. There is no established release cadence for the Miru Agent—features are simply released as soon as they are ready.
 
 ## Supported versions
 

--- a/docs/developers/device-api/overview.mdx
+++ b/docs/developers/device-api/overview.mdx
@@ -6,7 +6,7 @@ import DeviceAPICard from '/snippets/references/device-api/card.mdx';
 
 The Miru Device API is a REST API for programmatically interacting with the Miru Agent from an application running on the same device as the agent.
 
-The Device API is not available over the internet--it is only accessible from the device running the Miru Agent. It is useful for manually refreshing configurations, retrieving current configurations, and checking agent status from applications running on your devices.
+The Device API is not available over the internet—it is only accessible from the device running the Miru Agent. It is useful for manually refreshing configurations, retrieving current configurations, and checking agent status from applications running on your devices.
 
 The Device API is distinct from the Miru [Platform API](/docs/developers/platform-api/overview), which is a REST API for backend services and CI/CD pipelines to manage Miru resources.
 

--- a/docs/developers/device-api/versioning.mdx
+++ b/docs/developers/device-api/versioning.mdx
@@ -11,7 +11,7 @@ import { CardNewTab } from '/snippets/components/card.jsx';
 
 The Device API adheres to [semantic versioning](https://semver.org/), which was chosen so that on-device applications can easily determine API version compatibility.
 
-The Device API is currently in beta, signified by the `v0` prefix. There is no established release cadence for the Device API--features are simply released as soon as they are ready.
+The Device API is currently in beta, signified by the `v0` prefix. There is no established release cadence for the Device API—features are simply released as soon as they are ready.
 
 ## URL format
 
@@ -48,7 +48,7 @@ As rule of thumb, use the API version of the oldest agent version that is deploy
 
 ## Supported versions
 
-The Device API does not have its own support policy--its support is inherited from the Miru Agent. 
+The Device API does not have its own support policy—its support is inherited from the Miru Agent. 
 
 If a supported Miru Agent uses an API version, that API version is supported. You can find the supported Miru Agent versions on the [Agent Versions](/docs/developers/agent/versions) page.
 
@@ -86,7 +86,7 @@ During **beta** (`v0.x.y`)
 
 After **stable** (`v1.0`+)
 - Major version bumps (e.g. `v1.x` to `v2.0`) may include breaking changes
-- Minor version bumps (e.g. `v1.0` to `v1.1`) are additive only--no breaking changes
+- Minor version bumps (e.g. `v1.0` to `v1.1`) are additive only—no breaking changes
 
 ### Breaking changes
 

--- a/docs/getting-started/quick-start/create-release.mdx
+++ b/docs/getting-started/quick-start/create-release.mdx
@@ -63,7 +63,7 @@ Click the **New Config Type** button, supply the name `Mobility` and slug `mobil
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/config-types/create-dialog.png)
 </Frame>
 
-The provided slug is a unique identifier for the config type--it's how the CLI determines which config type a schema belongs to. As such, config schemas _must_ be annotated with the slug of the config type to which they belong.
+The provided slug is a unique identifier for the config type—it's how the CLI determines which config type a schema belongs to. As such, config schemas _must_ be annotated with the slug of the config type to which they belong.
 
 <CodeGroup>
 

--- a/docs/learn/deployments.mdx
+++ b/docs/learn/deployments.mdx
@@ -167,13 +167,13 @@ As you can see, the target status can only move _forward_, never backwards.
 
 Once a deployment's target status has been set to `deployed`, it can never be set to `staged` again.  Similarly, once a deployment's target status has been set to `archived`, it can never be set to `deployed` again.
 
-This is intentional--deployments are one-time use. Once a deployment has been deployed, it cannot be redeployed. You must create a new deployment with identical content to roll back.
+This is intentional—deployments are one-time use. Once a deployment has been deployed, it cannot be redeployed. You must create a new deployment with identical content to roll back.
 
 ## Activity Status
 
 The activity status is the _last known_ state of a deployment.
 
-We use _the last known state_ intentionally -- poor network connectivity can prevent devices from immediately syncing their activity state with the cloud. In practice, this isn't too common. However, it's still a critical point to keep in mind.
+We use _the last known state_ intentionally—poor network connectivity can prevent devices from immediately syncing their activity state with the cloud. In practice, this isn't too common. However, it's still a critical point to keep in mind.
 
 There are five possible activity states for a deployment.
 
@@ -234,7 +234,7 @@ As with the target status, activity states can only progress forward since deplo
 
 ## Error Status
 
-The error status is the _last known_ error state of a deployment. Again, we use _the last known state_ intentionally -- poor network connectivity can prevent devices from immediately syncing their error state to the cloud.
+The error status is the _last known_ error state of a deployment. Again, we use _the last known state_ intentionally—poor network connectivity can prevent devices from immediately syncing their error state to the cloud.
 
 The error status is independent of the activity and target statuses. The error status does not imply any particular activity or target state, and vice versa. The error status is only concerned with errors encountered during deployment.
 

--- a/docs/learn/devices/deployment-history.mdx
+++ b/docs/learn/devices/deployment-history.mdx
@@ -28,7 +28,7 @@ To view the details of any config instances in the deployment, click into the co
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/deployments/deployed-panel:configurations.png)
 </Frame>
 
-The content tab shows the config instance's parameters , while the metadata tab contains audit information--the author, creation date, description, etc.
+The content tab shows the config instance's parameters , while the metadata tab contains audit information—the author, creation date, description, etc.
 
 <Tabs>
   <Tab title="Content">

--- a/docs/learn/devices/manage.mdx
+++ b/docs/learn/devices/manage.mdx
@@ -88,7 +88,7 @@ To delete a device, click the ellipses (...) on the device you want to delete an
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/devices/ellipses-dropdown.png)
 </Frame>
 
-A confirmation dialog will appear--click **Delete** to confirm.
+A confirmation dialog will appear—click **Delete** to confirm.
 
 <Frame>
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/devices/delete-dialog.png)

--- a/docs/learn/devices/overview.mdx
+++ b/docs/learn/devices/overview.mdx
@@ -103,7 +103,7 @@ flowchart LR
 
 Devices begin in the `inactive` state. During the Miru Agent install process, devices briefly enter the `activating` state before transitioning to `online`.
 
-Once the Miru Agent has been activated on a device, the device remains `online` or `offline` for the remainder of its existence--devices don't transition back to `inactive` or `activating`.
+Once the Miru Agent has been activated on a device, the device remains `online` or `offline` for the remainder of its existence—devices don't transition back to `inactive` or `activating`.
 
 The only exception to this is when a device is [reactivated](/docs/learn/devices/manage#reactivate-a-device). During reactivation, devices briefly enter the `activating` state before transitioning back to `online`.
 

--- a/docs/learn/releases/deployment-history.mdx
+++ b/docs/learn/releases/deployment-history.mdx
@@ -28,7 +28,7 @@ To view the details of any config instances in the deployment, click into the co
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/deployments/deployed-panel:configurations.png)
 </Frame>
 
-The content tab contains the config instance's parameters, while the metadata tab contains audit information--the author, creation date, description, etc.
+The content tab contains the config instance's parameters, while the metadata tab contains audit information—the author, creation date, description, etc.
 
 <Tabs>
   <Tab title="Content">

--- a/docs/learn/releases/staging-area.mdx
+++ b/docs/learn/releases/staging-area.mdx
@@ -114,7 +114,7 @@ instance in the **Configurations** section of the panel.
 </Frame>
 
 The content tab contains the config instance's parameters, while the metadata tab
-contains audit information--the author, creation date, description, etc.
+contains audit information—the author, creation date, description, etc.
 
 <Tabs>
   <Tab title="Content">
@@ -173,7 +173,7 @@ To archive a single deployment, click the ellipsis (...) on the deployment and s
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/releases/stage/ellipses-dropdown:staged.png)
 </Frame>
 
-A confirmation dialog will appear--hit **Archive** to confirm.
+A confirmation dialog will appear—hit **Archive** to confirm.
 
 <Frame>
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/releases/stage/archive-dialog:single.png)
@@ -194,7 +194,7 @@ At the bottom of the page, click **Archive** from the available bulk actions.
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/releases/stage/bulk-actions.png)
 </Frame>
 
-A confirmation dialog will appear--hit **Archive** to confirm.
+A confirmation dialog will appear—hit **Archive** to confirm.
 
 <Frame>
   ![Miru UI screenshot](https://assets.mirurobotics.com/docs/v03/images/releases/stage/archive-dialog:bulk.png)
@@ -240,7 +240,7 @@ Our device is about to be upgraded to release `v1.6` though, so we've staged dep
 `DPL-Q4CeX` for the upcoming upgrade.
 
 However, before the upgrade occurs, our device receives some configuration updates on
-release `v1.5`--`DPL-Npfzv` is patched with `DPL-BFwc3`. Since it's often the case that
+release `v1.5`—`DPL-Npfzv` is patched with `DPL-BFwc3`. Since it's often the case that
 this patch also needs to be applied to the staged deployment `DPL-Q4CeX`, we say
 `DPL-Q4CeX` has _drifted_.
 

--- a/docs/learn/schemas/overview.mdx
+++ b/docs/learn/schemas/overview.mdx
@@ -51,7 +51,7 @@ import {Framed} from '/snippets/components/framed.jsx';
 
   A hash of the canonicalized schema content.
 
-  Digests are computed by converting schemas to a canonical format--a format that ignores whitespace, comments, and other non-semantic differences--and then hashing the result. This is useful for comparing schemas and detecting duplicates.
+  Digests are computed by converting schemas to a canonical format—a format that ignores whitespace, comments, and other non-semantic differences—and then hashing the result. This is useful for comparing schemas and detecting duplicates.
 
   Examples: `sha256:45YeoJJ2btBnAKQztAEXEjHsqyyQfC1z1Mw3LLM4xMUy`
 </ParamField>
@@ -76,7 +76,7 @@ import {Framed} from '/snippets/components/framed.jsx';
 
 ## Schema languages
 
-Config schemas are defined using a schema language--a formal language for describing the structure, constraints, and data types of a configuration.
+Config schemas are defined using a schema language—a formal language for describing the structure, constraints, and data types of a configuration.
 
 Miru supports:
 
@@ -146,7 +146,7 @@ The schema defines what constitutes a valid config instance in several different
 - Names the available properties
 - Organizes the configuration structure, placing some properties at the root while nesting other properties into logical groups
 - Gives each property a type, such as `number`, `boolean`, etc.
-- Constrains the values of each property--minimums, maximums, enumerations, etc.
+- Constrains the values of each property—minimums, maximums, enumerations, etc.
 - Supplies default values to properties where appropriate
 
 Most of these constraints are optional, and many features of JSON Schema are omitted here, but this gives you a flavor of what schemas are capable of.
@@ -179,7 +179,7 @@ Although simple in concept, schemas are a powerful tool for preventing typos, mi
 
 While schemas provide significant value in production deployments, defining one from scratch can be a considerable undertaking.
 
-Many teams find it best to begin with an empty schema--one that accepts any configuration--and gradually add constraints. This approach allows you to define the most highly valued constraints first and progressively transition to stricter and stricter schemas as needed.
+Many teams find it best to begin with an empty schema—one that accepts any configuration—and gradually add constraints. This approach allows you to define the most highly valued constraints first and progressively transition to stricter and stricter schemas as needed.
 
 Below are the empty schemas for JSON Schema and CUE, respectively.
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -12,6 +12,11 @@ if ! command -v pnpm >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v go >/dev/null 2>&1; then
+  echo "go is required for MDX prose linting. Install Go and rerun ./scripts/lint.sh." >&2
+  exit 1
+fi
+
 cd "${repo_root}"
 
 collect_files() {
@@ -55,6 +60,10 @@ if [[ ${#openapi_targets[@]} -eq 0 ]]; then
   echo "No OpenAPI specs found under ${content_root}/docs/references." >&2
   exit 1
 fi
+
+echo "== MDX Prose =="
+(cd "${repo_root}/tools/lint" && go build -o lint .)
+"${repo_root}/tools/lint/lint" "${mdx_targets[@]}"
 
 echo "== ESLint (MDX) =="
 pnpm exec eslint --max-warnings=0 "${mdx_targets[@]}"

--- a/snippets/definitions/release.mdx
+++ b/snippets/definitions/release.mdx
@@ -1,6 +1,6 @@
 A **release** is a version of software and its compatible config schemas.
 
-Within a fleet of robots, multiple software versions may be deployed -- each release defines which config schemas are valid for that version.
+Within a fleet of robots, multiple software versions may be deployed—each release defines which config schemas are valid for that version.
 
 For example, software release `v1.7.0` might specify the following schemas:
 

--- a/snippets/references/cli/releases/create/cue-packages.mdx
+++ b/snippets/references/cli/releases/create/cue-packages.mdx
@@ -15,7 +15,7 @@ Each file defines a portion of the schema, which is then aggregated by the `main
 
 The Miru CLI automatically identifies CUE packages for you when creating a release using the `package` clause at the top of each schema file (as described in the [CUE documentation](https://cuelang.org/docs/tour/packages/packages/)).
 
-You don't need to explicitly specify the package in the CLI command--just provide the path to the package directory or to the individual schema files within the package.
+You don't need to explicitly specify the package in the CLI command—just provide the path to the package directory or to the individual schema files within the package.
 
 **Annotations**
 

--- a/tools/lint/go.mod
+++ b/tools/lint/go.mod
@@ -1,0 +1,3 @@
+module github.com/mirurobotics/docs/tools/lint
+
+go 1.24

--- a/tools/lint/main.go
+++ b/tools/lint/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: lint <file>...")
+		os.Exit(2)
+	}
+
+	rules := []Rule{
+		NoDoubleDash{},
+	}
+
+	var allViolations []Violation
+	exitCode := 0
+
+	for _, path := range os.Args[1:] {
+		violations, err := lintFile(path, rules)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "lint: %s: %v\n", path, err)
+			exitCode = 2
+			continue
+		}
+		allViolations = append(allViolations, violations...)
+	}
+
+	for _, v := range allViolations {
+		fmt.Printf("%s:%d:%d: %s\n", v.File, v.Line, v.Col, v.Message)
+	}
+
+	if len(allViolations) > 0 && exitCode == 0 {
+		exitCode = 1
+	}
+	os.Exit(exitCode)
+}
+
+func lintFile(path string, rules []Rule) ([]Violation, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := NewScanner()
+	lineScanner := bufio.NewScanner(f)
+	var violations []Violation
+
+	for lineScanner.Scan() {
+		spans := scanner.ScanLine(lineScanner.Text())
+		for _, rule := range rules {
+			violations = append(violations, rule.Check(path, scanner.LineNum(), spans)...)
+		}
+	}
+
+	if err := lineScanner.Err(); err != nil {
+		return nil, err
+	}
+	return violations, nil
+}

--- a/tools/lint/rules.go
+++ b/tools/lint/rules.go
@@ -1,0 +1,44 @@
+package main
+
+// Violation represents a single lint finding.
+type Violation struct {
+	File    string
+	Line    int
+	Col     int // 1-based byte column
+	Message string
+}
+
+// Rule checks prose spans on a single line and returns any violations found.
+type Rule interface {
+	Check(file string, line int, spans []ProseSpan) []Violation
+}
+
+// NoDoubleDash flags occurrences of exactly two consecutive hyphens ("--")
+// in prose that are not part of a longer dash sequence ("---", "----", etc.).
+type NoDoubleDash struct{}
+
+func (r NoDoubleDash) Check(file string, line int, spans []ProseSpan) []Violation {
+	var violations []Violation
+	for _, span := range spans {
+		text := span.Text
+		for i := 0; i < len(text)-1; i++ {
+			if text[i] != '-' || text[i+1] != '-' {
+				continue
+			}
+			// Check it's not part of a longer sequence
+			if i > 0 && text[i-1] == '-' {
+				continue
+			}
+			if i+2 < len(text) && text[i+2] == '-' {
+				continue
+			}
+			violations = append(violations, Violation{
+				File:    file,
+				Line:    line,
+				Col:     span.StartCol + i,
+				Message: "no-double-dash: use em dash '\u2014' instead of '--'",
+			})
+		}
+	}
+	return violations
+}

--- a/tools/lint/rules_test.go
+++ b/tools/lint/rules_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNoDoubleDash(t *testing.T) {
+	rule := NoDoubleDash{}
+
+	tests := []struct {
+		name       string
+		input      string
+		wantCount  int
+		wantCols   []int // 1-based columns of expected violations
+	}{
+		{
+			name:      "double dash in prose",
+			input:     "config type--it determines",
+			wantCount: 1,
+			wantCols:  []int{12},
+		},
+		{
+			name:      "triple dash not flagged",
+			input:     "use ---",
+			wantCount: 0,
+		},
+		{
+			name:      "quadruple dash not flagged",
+			input:     "use ----",
+			wantCount: 0,
+		},
+		{
+			name:      "single dash not flagged",
+			input:     "a-b",
+			wantCount: 0,
+		},
+		{
+			name:      "two separate double dashes",
+			input:     "a--b and c--d",
+			wantCount: 2,
+			wantCols:  []int{2, 11},
+		},
+		{
+			name:      "double dash at start of line",
+			input:     "--start",
+			wantCount: 1,
+			wantCols:  []int{1},
+		},
+		{
+			name:      "double dash at end of line",
+			input:     "end--",
+			wantCount: 1,
+			wantCols:  []int{4},
+		},
+		{
+			name:      "just double dash",
+			input:     "--",
+			wantCount: 1,
+			wantCols:  []int{1},
+		},
+		{
+			name:      "no dashes",
+			input:     "hello world",
+			wantCount: 0,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spans := []ProseSpan{{StartCol: 1, Text: tt.input}}
+			if tt.input == "" {
+				spans = nil
+			}
+			violations := rule.Check("test.mdx", 1, spans)
+			if len(violations) != tt.wantCount {
+				t.Errorf("expected %d violations, got %d: %v", tt.wantCount, len(violations), violations)
+				return
+			}
+			for i, wantCol := range tt.wantCols {
+				if violations[i].Col != wantCol {
+					t.Errorf("violation %d: expected col %d, got %d", i, wantCol, violations[i].Col)
+				}
+			}
+		})
+	}
+}
+
+func TestNoDoubleDashWithOffset(t *testing.T) {
+	rule := NoDoubleDash{}
+
+	// Simulate a span that starts at column 10 (e.g. after inline code)
+	spans := []ProseSpan{{StartCol: 10, Text: "a--b"}}
+	violations := rule.Check("test.mdx", 1, spans)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].Col != 11 {
+		t.Errorf("expected col 11, got %d", violations[0].Col)
+	}
+}
+
+func TestNoDoubleDashIntegration(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantLines []int
+	}{
+		{
+			name: "double dash in prose after frontmatter",
+			content: "---\ntitle: Test\n---\n\nconfig type--it determines",
+			wantCount: 1,
+			wantLines: []int{5},
+		},
+		{
+			name: "double dash in code block not flagged",
+			content: "---\ntitle: Test\n---\n\n```bash\nmiru --version\n```",
+			wantCount: 0,
+		},
+		{
+			name: "double dash in inline code not flagged",
+			content: "---\ntitle: Test\n---\n\nUse `--version` flag",
+			wantCount: 0,
+		},
+		{
+			name: "double dash in frontmatter not flagged",
+			content: "---\ntitle: Test--Title\n---\n\nClean prose",
+			wantCount: 0,
+		},
+		{
+			name: "double dash in JSX attribute not flagged",
+			content: "---\ntitle: Test\n---\n\n<ParamField path=\"--version\" type=\"string\">",
+			wantCount: 0,
+		},
+		{
+			name: "frontmatter dashes not flagged",
+			content: "---\ntitle: Test\n---\n\nClean",
+			wantCount: 0,
+		},
+		{
+			name: "thematic break not flagged",
+			content: "---\ntitle: Test\n---\n\n---\n\nClean",
+			wantCount: 0,
+		},
+		{
+			name: "table separator not flagged",
+			content: "---\ntitle: Test\n---\n\n| A | B |\n|---|---|\n| 1 | 2 |",
+			wantCount: 0,
+		},
+		{
+			name: "HTML comment not flagged",
+			content: "---\ntitle: Test\n---\n\n<!-- --test -->",
+			wantCount: 0,
+		},
+		{
+			name: "multiline HTML comment not flagged",
+			content: "---\ntitle: Test\n---\n\n<!-- \n--test\n-->",
+			wantCount: 0,
+		},
+		{
+			name: "import not flagged",
+			content: "---\ntitle: Test\n---\n\nimport Foo from '--bar'",
+			wantCount: 0,
+		},
+		{
+			name: "mixed line with inline code and prose dash",
+			content: "---\ntitle: Test\n---\n\nUse `--flag` for type--detection",
+			wantCount: 1,
+			wantLines: []int{5},
+		},
+	}
+
+	rule := NoDoubleDash{}
+	rules := []Rule{rule}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := NewScanner()
+			var violations []Violation
+			for i, line := range strings.Split(tt.content, "\n") {
+				spans := scanner.ScanLine(line)
+				for _, r := range rules {
+					violations = append(violations, r.Check("test.mdx", i+1, spans)...)
+				}
+			}
+			if len(violations) != tt.wantCount {
+				t.Errorf("expected %d violations, got %d: %v", tt.wantCount, len(violations), violations)
+				return
+			}
+			for i, wantLine := range tt.wantLines {
+				if violations[i].Line != wantLine {
+					t.Errorf("violation %d: expected line %d, got %d", i, wantLine, violations[i].Line)
+				}
+			}
+		})
+	}
+}

--- a/tools/lint/scanner.go
+++ b/tools/lint/scanner.go
@@ -1,0 +1,279 @@
+package main
+
+import "strings"
+
+// ProseSpan represents a contiguous segment of prose text within a line.
+// StartCol is the 1-based byte offset of the span's first character in the original line.
+type ProseSpan struct {
+	StartCol int
+	Text     string
+}
+
+type zone int
+
+const (
+	zoneProse zone = iota
+	zoneFrontmatter
+	zoneCodeBlock
+	zoneHTMLComment
+)
+
+// Scanner is a line-by-line state machine that classifies regions of an MDX
+// file as prose or excluded (frontmatter, code blocks, comments, etc.).
+type Scanner struct {
+	zone      zone
+	codeFence string // the fence marker (e.g. "```" or "~~~") to match for closing
+	lineNum   int
+}
+
+// NewScanner returns a scanner ready to process lines from the start of a file.
+func NewScanner() *Scanner {
+	return &Scanner{}
+}
+
+// LineNum returns the 1-based line number of the most recently scanned line.
+func (s *Scanner) LineNum() int {
+	return s.lineNum
+}
+
+// ScanLine processes the next line of input and returns the prose spans found
+// on that line. Returns nil if the entire line is excluded.
+func (s *Scanner) ScanLine(line string) []ProseSpan {
+	s.lineNum++
+
+	switch s.zone {
+	case zoneFrontmatter:
+		if strings.TrimRight(line, " \t") == "---" {
+			s.zone = zoneProse
+		}
+		return nil
+
+	case zoneCodeBlock:
+		trimmed := strings.TrimSpace(line)
+		if trimmed == s.codeFence {
+			s.zone = zoneProse
+		}
+		return nil
+
+	case zoneHTMLComment:
+		idx := strings.Index(line, "-->")
+		if idx < 0 {
+			return nil
+		}
+		s.zone = zoneProse
+		rest := line[idx+3:]
+		if len(strings.TrimSpace(rest)) == 0 {
+			return nil
+		}
+		return s.maskInlineRegions(rest, idx+3)
+	}
+
+	// zoneProse: check for zone entry
+	if s.lineNum == 1 && strings.TrimRight(line, " \t") == "---" {
+		s.zone = zoneFrontmatter
+		return nil
+	}
+
+	if fence, ok := codeFenceOpen(line); ok {
+		s.zone = zoneCodeBlock
+		s.codeFence = fence
+		return nil
+	}
+
+	if isThematicBreak(line) {
+		return nil
+	}
+
+	if isTableSeparator(line) {
+		return nil
+	}
+
+	if isImportExport(line) {
+		return nil
+	}
+
+	return s.maskInlineRegions(line, 0)
+}
+
+// codeFenceOpen checks if a line opens a fenced code block.
+// Returns the bare fence string (e.g. "```") and true, or ("", false).
+// MDX allows code fences at any indentation level (nested inside JSX),
+// so we don't enforce the CommonMark 0-3 space indentation limit.
+func codeFenceOpen(line string) (string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+
+	if len(trimmed) >= 3 && trimmed[:3] == "```" {
+		return "```", true
+	}
+	if len(trimmed) >= 3 && trimmed[:3] == "~~~" {
+		return "~~~", true
+	}
+	return "", false
+}
+
+// isThematicBreak returns true for lines that are markdown thematic breaks
+// made of dashes (e.g. "---", "----", "  ---").
+func isThematicBreak(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < 3 {
+		return false
+	}
+	for _, c := range trimmed {
+		if c != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// isTableSeparator returns true for markdown table separator rows
+// (lines containing only |, -, :, and spaces with at least one |).
+func isTableSeparator(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return false
+	}
+	hasPipe := false
+	for _, c := range trimmed {
+		switch c {
+		case '|':
+			hasPipe = true
+		case '-', ':', ' ':
+			// allowed
+		default:
+			return false
+		}
+	}
+	return hasPipe
+}
+
+// isImportExport returns true for MDX import/export statements.
+func isImportExport(line string) bool {
+	return strings.HasPrefix(line, "import ") || strings.HasPrefix(line, "export ")
+}
+
+// maskInlineRegions takes a prose line and returns spans with inline code,
+// HTML tags, and HTML comments masked out. baseCol is the 0-based byte
+// offset of line[0] within the original file line (used when processing
+// the tail of an HTML comment line). If an HTML comment opens but does not
+// close on this line, the scanner transitions to zoneHTMLComment.
+func (s *Scanner) maskInlineRegions(line string, baseCol int) []ProseSpan {
+	var spans []ProseSpan
+	i := 0
+	spanStart := 0
+
+	for i < len(line) {
+		switch {
+		// HTML comment start
+		case i+4 <= len(line) && line[i:i+4] == "<!--":
+			if i > spanStart {
+				spans = appendSpan(spans, line[spanStart:i], baseCol+spanStart)
+			}
+			end := strings.Index(line[i+4:], "-->")
+			if end >= 0 {
+				i = i + 4 + end + 3
+			} else {
+				// Comment doesn't close on this line — enter comment zone.
+				s.zone = zoneHTMLComment
+				return spans
+			}
+			spanStart = i
+
+		// HTML/JSX tag
+		case line[i] == '<':
+			if i > spanStart {
+				spans = appendSpan(spans, line[spanStart:i], baseCol+spanStart)
+			}
+			end := findTagEnd(line, i)
+			i = end
+			spanStart = i
+
+		// Inline code
+		case line[i] == '`':
+			if i > spanStart {
+				spans = appendSpan(spans, line[spanStart:i], baseCol+spanStart)
+			}
+			end := findInlineCodeEnd(line, i)
+			i = end
+			spanStart = i
+
+		default:
+			i++
+		}
+	}
+
+	if spanStart < len(line) {
+		spans = appendSpan(spans, line[spanStart:], baseCol+spanStart)
+	}
+	return spans
+}
+
+// findTagEnd returns the byte index just past the closing '>' of an HTML/JSX
+// tag starting at pos. If no closing '>' is found, returns len(line).
+func findTagEnd(line string, pos int) int {
+	i := pos + 1
+	for i < len(line) {
+		switch line[i] {
+		case '>':
+			return i + 1
+		case '"':
+			i++
+			for i < len(line) && line[i] != '"' {
+				i++
+			}
+		case '\'':
+			i++
+			for i < len(line) && line[i] != '\'' {
+				i++
+			}
+		}
+		if i < len(line) {
+			i++
+		}
+	}
+	return len(line)
+}
+
+// findInlineCodeEnd returns the byte index just past the closing backtick(s)
+// of inline code starting at pos. Handles both single and double backtick
+// delimiters (` and ``).
+func findInlineCodeEnd(line string, pos int) int {
+	// Count opening backticks
+	ticks := 0
+	i := pos
+	for i < len(line) && line[i] == '`' {
+		ticks++
+		i++
+	}
+
+	// Find matching closing backticks
+	for i < len(line) {
+		if line[i] == '`' {
+			closeTicks := 0
+			j := i
+			for j < len(line) && line[j] == '`' {
+				closeTicks++
+				j++
+			}
+			if closeTicks == ticks {
+				return j
+			}
+			i = j
+		} else {
+			i++
+		}
+	}
+
+	// No closing backticks found; treat the opening backticks as literal text.
+	return pos + ticks
+}
+
+func appendSpan(spans []ProseSpan, text string, col int) []ProseSpan {
+	if len(strings.TrimSpace(text)) == 0 {
+		return spans
+	}
+	return append(spans, ProseSpan{
+		StartCol: col + 1, // 1-based
+		Text:     text,
+	})
+}

--- a/tools/lint/scanner_test.go
+++ b/tools/lint/scanner_test.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFrontmatter(t *testing.T) {
+	s := NewScanner()
+
+	if spans := s.ScanLine("---"); spans != nil {
+		t.Errorf("frontmatter open: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine(`title: "Test"`); spans != nil {
+		t.Errorf("frontmatter body: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("---"); spans != nil {
+		t.Errorf("frontmatter close: expected nil, got %v", spans)
+	}
+
+	spans := s.ScanLine("Hello world")
+	if len(spans) != 1 || spans[0].Text != "Hello world" {
+		t.Errorf("after frontmatter: expected prose, got %v", spans)
+	}
+}
+
+func TestFencedCodeBlock(t *testing.T) {
+	s := NewScanner()
+
+	if spans := s.ScanLine("```bash"); spans != nil {
+		t.Errorf("code fence open: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("miru release create --version v1.0.0"); spans != nil {
+		t.Errorf("code block body: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("```"); spans != nil {
+		t.Errorf("code fence close: expected nil, got %v", spans)
+	}
+
+	spans := s.ScanLine("After code")
+	if len(spans) != 1 || spans[0].Text != "After code" {
+		t.Errorf("after code block: expected prose, got %v", spans)
+	}
+}
+
+func TestTildeFence(t *testing.T) {
+	s := NewScanner()
+
+	if spans := s.ScanLine("~~~"); spans != nil {
+		t.Errorf("tilde fence open: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("--flag"); spans != nil {
+		t.Errorf("tilde block body: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("~~~"); spans != nil {
+		t.Errorf("tilde fence close: expected nil, got %v", spans)
+	}
+}
+
+func TestInlineCode(t *testing.T) {
+	s := NewScanner()
+	// Skip frontmatter
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	spans := s.ScanLine("Use the `--version` flag here")
+	// Should get: "Use the " and " flag here"
+	if len(spans) != 2 {
+		t.Fatalf("inline code: expected 2 spans, got %d: %v", len(spans), spans)
+	}
+	if spans[0].Text != "Use the " {
+		t.Errorf("span 0: expected 'Use the ', got %q", spans[0].Text)
+	}
+	if spans[0].StartCol != 1 {
+		t.Errorf("span 0 col: expected 1, got %d", spans[0].StartCol)
+	}
+	if spans[1].Text != " flag here" {
+		t.Errorf("span 1: expected ' flag here', got %q", spans[1].Text)
+	}
+}
+
+func TestDoubleBacktickInlineCode(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	spans := s.ScanLine("Use ``--flag`` here")
+	if len(spans) != 2 {
+		t.Fatalf("double backtick: expected 2 spans, got %d: %v", len(spans), spans)
+	}
+	if spans[0].Text != "Use " {
+		t.Errorf("span 0: expected 'Use ', got %q", spans[0].Text)
+	}
+	if spans[1].Text != " here" {
+		t.Errorf("span 1: expected ' here', got %q", spans[1].Text)
+	}
+}
+
+func TestHTMLComment(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	spans := s.ScanLine("before <!-- --test --> after")
+	if len(spans) != 2 {
+		t.Fatalf("html comment: expected 2 spans, got %d: %v", len(spans), spans)
+	}
+	if spans[0].Text != "before " {
+		t.Errorf("span 0: expected 'before ', got %q", spans[0].Text)
+	}
+	if spans[1].Text != " after" {
+		t.Errorf("span 1: expected ' after', got %q", spans[1].Text)
+	}
+}
+
+func TestMultilineHTMLComment(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	spans := s.ScanLine("before <!-- start")
+	if len(spans) != 1 || spans[0].Text != "before " {
+		t.Errorf("comment open line: expected 'before ', got %v", spans)
+	}
+
+	if spans := s.ScanLine("-- middle"); spans != nil {
+		t.Errorf("comment body: expected nil, got %v", spans)
+	}
+
+	spans = s.ScanLine("--> after")
+	if len(spans) != 1 || spans[0].Text != " after" {
+		t.Errorf("comment close line: expected ' after', got %v", spans)
+	}
+}
+
+func TestJSXTag(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	spans := s.ScanLine(`before <ParamField path="--version" type="string"> after`)
+	if len(spans) != 2 {
+		t.Fatalf("jsx tag: expected 2 spans, got %d: %v", len(spans), spans)
+	}
+	if spans[0].Text != "before " {
+		t.Errorf("span 0: expected 'before ', got %q", spans[0].Text)
+	}
+	if spans[1].Text != " after" {
+		t.Errorf("span 1: expected ' after', got %q", spans[1].Text)
+	}
+}
+
+func TestThematicBreak(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	// Thematic break (not frontmatter since we're past it)
+	if spans := s.ScanLine("---"); spans != nil {
+		t.Errorf("thematic break: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("----"); spans != nil {
+		t.Errorf("long thematic break: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("  ---"); spans != nil {
+		t.Errorf("indented thematic break: expected nil, got %v", spans)
+	}
+}
+
+func TestTableSeparator(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	if spans := s.ScanLine("|---|---|"); spans != nil {
+		t.Errorf("table separator: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("| --- | --- |"); spans != nil {
+		t.Errorf("spaced table separator: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("|:---:|:---:|"); spans != nil {
+		t.Errorf("aligned table separator: expected nil, got %v", spans)
+	}
+}
+
+func TestImportExport(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	if spans := s.ScanLine("import Foo from './foo'"); spans != nil {
+		t.Errorf("import: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("export default Bar"); spans != nil {
+		t.Errorf("export: expected nil, got %v", spans)
+	}
+}
+
+func TestIndentedCodeFence(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	// MDX nests code blocks inside JSX at arbitrary indentation
+	if spans := s.ScanLine("    ```bash Empty Schemas"); spans != nil {
+		t.Errorf("indented fence open: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("      --version v1.0.0"); spans != nil {
+		t.Errorf("indented fence body: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("    ```"); spans != nil {
+		t.Errorf("indented fence close: expected nil, got %v", spans)
+	}
+
+	spans := s.ScanLine("After indented code")
+	if len(spans) != 1 || spans[0].Text != "After indented code" {
+		t.Errorf("after indented code: expected prose, got %v", spans)
+	}
+}
+
+func TestUnclosedQuoteInTag(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	// Must not panic on malformed tags with unclosed quotes
+	spans := s.ScanLine(`<tag attr="unclosed`)
+	if spans != nil {
+		t.Errorf("unclosed double quote tag: expected nil, got %v", spans)
+	}
+
+	spans = s.ScanLine(`<tag attr='unclosed`)
+	if spans != nil {
+		t.Errorf("unclosed single quote tag: expected nil, got %v", spans)
+	}
+}
+
+func TestLineNum(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+	s.ScanLine("line three")
+
+	if s.LineNum() != 3 {
+		t.Errorf("expected LineNum 3, got %d", s.LineNum())
+	}
+}
+
+func TestProseLineColumns(t *testing.T) {
+	s := NewScanner()
+	s.ScanLine("---")
+	s.ScanLine("---")
+
+	spans := s.ScanLine("plain prose line")
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].StartCol != 1 {
+		t.Errorf("expected col 1, got %d", spans[0].StartCol)
+	}
+	if spans[0].Text != "plain prose line" {
+		t.Errorf("expected 'plain prose line', got %q", spans[0].Text)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `tools/lint`, a Go-based MDX prose linter with a `no-double-dash` rule that flags `--` in prose (suggesting em dash replacement)
- Scanner skips frontmatter, fenced code blocks, inline code, HTML comments, JSX tags, thematic breaks, table separators, and import/export lines
- Integrate into `scripts/lint.sh` and CI workflow (`setup-go` step)
- Fix 32 existing `--` occurrences across 18 MDX files with proper em dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)