### PR TITLE
ci: enable CI on branch pushes and rename CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,12 @@ name: CodeQL
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
+      - staging
+      - uat
+      - production
   schedule:
     - cron: '31 7 * * 3'
   workflow_call:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,8 +19,8 @@ permissions:
   security-events: write
 
 jobs:
-  analyze:
-    name: Analyze
+  codeql:
+    name: CodeQL
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,13 @@ name: Lint
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
+      - staging
+      - uat
+      - production
+  workflow_call:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Enable lint and CodeQL workflows to trigger on pushes to main, staging, uat, and production branches
- Add `workflow_call` trigger to lint workflow
- Rename `codeql-analysis.yml` to `codeql.yml` and standardize job name