### PR TITLE
ci: remove codeql matrix strategy

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,14 +20,7 @@ permissions:
 
 jobs:
   codeql:
-    name: CodeQL
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - javascript
 
     steps:
       - name: Checkout
@@ -39,7 +32,7 @@ jobs:
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
         with:
           config-file: .github/codeql/codeql-config.yml
-          languages: ${{ matrix.language }}
+          languages: javascript
 
       - name: Autobuild
         id: autobuild


### PR DESCRIPTION
## Summary
- Remove matrix strategy from CodeQL analysis workflow, simplifying the CI configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)