### PR TITLE
docs: add security vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of Miru seriously. If you discover a security vulnerability, please report it through GitHub's Private Vulnerability Reporting.
+
+**To report a vulnerability:**
+
+1. Navigate to the **Security** tab of this repository
+2. Click **Report a vulnerability**
+3. Fill out the form with as much detail as possible
+
+Please **do not** open a public issue for security vulnerabilities.
+
+## What to Include
+
+To help us triage and resolve the issue quickly, please include:
+
+- A description of the vulnerability and its potential impact
+- Step-by-step reproduction instructions
+- Affected versions
+- Any relevant logs, screenshots, or proof-of-concept code
+
+## What to Expect
+
+- **Acknowledgement** within 48 hours of your report
+- **Status updates** as we investigate and work toward a fix
+- **Credit** in the advisory for responsible disclosure (if desired)
+
+We aim to confirm, patch, and disclose vulnerabilities as quickly as possible. The timeline depends on severity and complexity, but we will keep you informed throughout the process.
+
+## Scope
+
+**In scope:**
+
+- Security issues in this repository's code
+- Vulnerabilities in direct dependencies
+
+**Out of scope:**
+
+- Social engineering attacks
+- Denial of service attacks
+- Issues in third-party services or infrastructure not maintained by Miru
+- Findings from automated scanners without demonstrated impact
+
+## Supported Versions
+
+Only the latest release is supported with security updates.
+
+## Safe Harbor
+
+We consider security research conducted in good faith under this policy to be authorized. We will not pursue legal action against researchers who:
+
+- Act in good faith and follow this policy
+- Avoid privacy violations, data destruction, and service disruption
+- Report vulnerabilities promptly and do not disclose publicly before a fix is available


### PR DESCRIPTION
## Summary
- Add `SECURITY.md` with vulnerability reporting instructions via GitHub Private Vulnerability Reporting
- Includes response timeline expectations, scope definitions, and safe harbor language

## Test plan
- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Confirm "Report a vulnerability" button appears on Security tab (requires PVR to be enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)