### PR TITLE
chore: add preflight.sh script

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+echo "=== Lint ==="
+./scripts/lint.sh

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -6,3 +6,7 @@ cd "$REPO_ROOT"
 
 echo "=== Lint ==="
 ./scripts/lint.sh
+echo ""
+
+echo "=== Audit ==="
+./scripts/audit.sh

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+echo "=== Lint Smoke Tests ==="
+pnpm run test:lint
+echo ""
+
 echo "=== Lint ==="
 ./scripts/lint.sh
 echo ""


### PR DESCRIPTION
## Summary

- Standardize on `scripts/preflight.sh` as the local validation entry point, matching the `$preflight` agent skill convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)