### PR TITLE
docs: nudge users to run brew update before installing CLI

### DIFF
--- a/docs/developers/cli/install.mdx
+++ b/docs/developers/cli/install.mdx
@@ -23,6 +23,10 @@ To upgrade the Miru CLI to the latest version, run the upgrade command in your l
     ```bash
     brew upgrade mirurobotics/cli/miru
     ```
+
+    <Info>
+      If you are not seeing the latest CLI version, run `brew update` first to refresh your local Homebrew tap, then re-run the install or upgrade command.
+    </Info>
   </Tab>
 </Tabs>
 

--- a/snippets/references/cli/install.mdx
+++ b/snippets/references/cli/install.mdx
@@ -12,6 +12,10 @@ To install the Miru CLI, run the installation command in your local machine's te
     ```bash
     brew install mirurobotics/cli/miru
     ```
+
+    <Info>
+      If you are not seeing the latest CLI version, run `brew update` first to refresh your local Homebrew tap, then re-run the install or upgrade command.
+    </Info>
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

- Add an `<Info>` callout to the macOS tab of the CLI install snippet (`snippets/references/cli/install.mdx`) advising users to run `brew update` first if they aren't seeing the latest CLI version.
- Add the same `<Info>` callout to the macOS tab of the Upgrade section in the parent install page (`docs/developers/cli/install.mdx`).

## Motivation

A user recently installed an older CLI release because their local Homebrew tap was stale: `brew install mirurobotics/cli/miru` returned `v0.9.1` even though `v0.9.2` was available, and `brew upgrade` had the same problem until they ran `brew update` to refresh the tap. The CLI's once-per-day upgrade-available message had also been suppressed for them, so the user-visible flow had nothing pointing them at `brew update`. This callout converts a confusing silent-failure experience into a one-line self-service fix.

Linux is unaffected — its install path uses a `curl` script that always pulls the latest binary from GitHub directly, so there is no local tap cache that can go stale.

## Test plan

- [ ] Visually verify the rendered `<Info>` callout in the Mintlify dev preview, on both the install snippet and the Upgrade section's macOS tab.
- [ ] Confirm the Linux tabs in both files are unchanged.
- [ ] Confirm the existing `<Note>` about Windows-not-supported is still present at the bottom of the install snippet.
- [ ] Confirm rendered text reads naturally in both contexts ("install or upgrade command" wording is intentional so the same string fits both tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)