### PR TITLE
docs: clarify instance file path controls deployment file type

### DIFF
--- a/docs/getting-started/quick-start/create-release.mdx
+++ b/docs/getting-started/quick-start/create-release.mdx
@@ -47,6 +47,10 @@ If you're unfamiliar with schema languages, we recommend starting with [JSON Sch
 
 </Tabs>
 
+<Note>
+  The instance file path annotation controls the type of file that config instances are deployed as. Currently, JSON (`.json`) and YAML (`.yaml`, `.yml`) are supported.
+</Note>
+
 ## Create the config types
 
 To be able to push the schemas to Miru, we must first create config types to house them. We'll start with the `Mobility` config type.

--- a/docs/learn/schemas/overview.mdx
+++ b/docs/learn/schemas/overview.mdx
@@ -62,6 +62,8 @@ import AgentYamlSupport from '/snippets/agent/yaml-support.mdx';
 
   The instance file path is the file path to deploy config instances (for this schema) on a device, relative to the `/srv/miru/config_instances` directory.
 
+  Instance file paths control the type of file that config instances are deployed as. Currently, JSON (`.json`) and YAML (`.yaml`, `.yml`) are supported.
+
   The default instance file path for a schema is `{config-type-slug}.json`, which deploys config instances to `/srv/miru/config_instances/{config-type-slug}.json`.
 
   Examples: `/v1/mobility.json`, `/config/safety.yaml`

--- a/snippets/getting-started/empty-cue-schemas.mdx
+++ b/snippets/getting-started/empty-cue-schemas.mdx
@@ -1,20 +1,20 @@
 <CodeGroup>
 ```cue Communication
-@miru(config_type="communication")
+@miru(config_type="communication",instance_filepath="communication.yaml")
 {
 	...
 }
 ```
 
 ```cue Mobility
-@miru(config_type="mobility")
+@miru(config_type="mobility",instance_filepath="mobility.json")
 {
 	...
 }
 ```
 
 ```cue Planning
-@miru(config_type="planning")
+@miru(config_type="planning",instance_filepath="planning.json")
 {
 	...
 }

--- a/snippets/getting-started/empty-json-schemas.mdx
+++ b/snippets/getting-started/empty-json-schemas.mdx
@@ -1,16 +1,19 @@
 <CodeGroup>
 ```yaml Communication
 x-miru-config-type: "communication"
+x-miru-instance-filepath: "communication.yaml"
 $schema: "http://json-schema.org/draft/2020-12/schema"
 ```
 
 ```yaml Mobility
 x-miru-config-type: "mobility"
+x-miru-instance-filepath: "mobility.json"
 $schema: "http://json-schema.org/draft/2020-12/schema"
 ```
 
 ```yaml Planning
 x-miru-config-type: "planning"
+x-miru-instance-filepath: "planning.json"
 $schema: "http://json-schema.org/draft/2020-12/schema"
 ```
 </CodeGroup>

--- a/snippets/getting-started/strict-cue-schemas.mdx
+++ b/snippets/getting-started/strict-cue-schemas.mdx
@@ -1,7 +1,7 @@
 
 <CodeGroup>
 ```cue Communication expandable
-@miru(config_type="communication")
+@miru(config_type="communication",instance_filepath="communication.yaml")
 {
 	control_loop_rate_hz: int & >=1 & <=1000 | *50
 	watchdog_timeout_ms: int & >=100 & <=5000 | *500
@@ -30,7 +30,7 @@
 ```
 
 ```cue Mobility expandable
-@miru(config_type="mobility")
+@miru(config_type="mobility",instance_filepath="mobility.json")
 {
 	max_linear_speed_mps: number & >=0.1 & <=5.0 | *1.2
 	max_angular_speed_radps: number & >=0.1 & <=3.0 | *1.0
@@ -45,7 +45,7 @@
 ```
 
 ```cue Planning expandable
-@miru(config_type="planning")
+@miru(config_type="planning",instance_filepath="planning.json")
 {
 	planning_frequency_hz: number & >=1.0 & <=100.0 | *20.0
 	control_frequency_hz: number & >=10.0 & <=200.0 | *50.0

--- a/snippets/getting-started/strict-json-schemas.mdx
+++ b/snippets/getting-started/strict-json-schemas.mdx
@@ -2,6 +2,7 @@
 <CodeGroup>
 ```yaml Communication expandable
 x-miru-config-type: "communication"
+x-miru-instance-filepath: "communication.yaml"
 $schema: "http://json-schema.org/draft/2020-12/schema"
 type: object
 required:
@@ -118,6 +119,7 @@ properties:
 
 ```yaml Mobility expandable
 x-miru-config-type: "mobility"
+x-miru-instance-filepath: "mobility.json"
 $schema: "http://json-schema.org/draft/2020-12/schema"
 type: object
 properties:
@@ -164,6 +166,7 @@ required:
 
 ```yaml Planning expandable
 x-miru-config-type: "planning"
+x-miru-instance-filepath: "planning.json"
 $schema: "http://json-schema.org/draft/2020-12/schema"
 type: object
 required:

--- a/snippets/references/cli/releases/create/schema-annotations.mdx
+++ b/snippets/references/cli/releases/create/schema-annotations.mdx
@@ -20,6 +20,8 @@
 <ParamField path="instance file path">
   The instance file path is the file system location that config instances for this schema are deployed to relative to the `/srv/miru/config_instances` directory.
 
+  Instance file paths control the type of file that config instances are deployed as. Currently, JSON (`.json`) and YAML (`.yaml`, `.yml`) are supported.
+
   This annotation is optional and defaults to `{config-type-slug}.json`, which deploys config instances to `/srv/miru/config_instances/{config-type-slug}.json` on a given device.
 
   <CodeGroup>
@@ -35,5 +37,5 @@
 
   </CodeGroup>
 
-  Examples: `/v1/mobility.json`, `/safety.json`, `configs/perception.json`
+  Examples: `/v1/mobility.json`, `/safety.yaml`
 </ParamField>


### PR DESCRIPTION
## Summary
- Add notes in the getting-started quick start, schemas overview, and CLI release reference explaining that the instance file path annotation determines whether config instances are deployed as JSON or YAML.
- Update the empty/strict CUE and JSON Schema snippets to include `instance_filepath` annotations demonstrating both file types.