### PR TITLE
fix(lint): codeFenceOpen returns full fence prefix, not hardcoded 3 chars

### DIFF
--- a/tools/lint/rules_test.go
+++ b/tools/lint/rules_test.go
@@ -110,6 +110,11 @@ func TestNoDoubleDashIntegration(t *testing.T) {
 			wantCount: 0,
 		},
 		{
+			name:      "double dash inside 4-backtick code block not flagged",
+			content:   "---\ntitle: Test\n---\n\n````bash\nmiru --version\n````",
+			wantCount: 0,
+		},
+		{
 			name:      "double dash in inline code not flagged",
 			content:   "---\ntitle: Test\n---\n\nUse `--version` flag",
 			wantCount: 0,

--- a/tools/lint/scanner.go
+++ b/tools/lint/scanner.go
@@ -99,12 +99,22 @@ func (s *Scanner) ScanLine(line string) []ProseSpan {
 func codeFenceOpen(line string) (string, bool) {
 	trimmed := strings.TrimLeft(line, " \t")
 
-	if len(trimmed) >= 3 && trimmed[:3] == "```" {
-		return "```", true
+	count := 0
+	for count < len(trimmed) && trimmed[count] == '`' {
+		count++
 	}
-	if len(trimmed) >= 3 && trimmed[:3] == "~~~" {
-		return "~~~", true
+	if count >= 3 {
+		return trimmed[:count], true
 	}
+
+	count = 0
+	for count < len(trimmed) && trimmed[count] == '~' {
+		count++
+	}
+	if count >= 3 {
+		return trimmed[:count], true
+	}
+
 	return "", false
 }
 

--- a/tools/lint/scanner_test.go
+++ b/tools/lint/scanner_test.go
@@ -56,6 +56,45 @@ func TestTildeFence(t *testing.T) {
 	}
 }
 
+func TestFourBacktickFence(t *testing.T) {
+	s := NewScanner()
+
+	if spans := s.ScanLine("````mdx"); spans != nil {
+		t.Errorf("4-backtick fence open: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("--flag"); spans != nil {
+		t.Errorf("4-backtick block body: expected nil, got %v", spans)
+	}
+	if spans := s.ScanLine("````"); spans != nil {
+		t.Errorf("4-backtick fence close: expected nil, got %v", spans)
+	}
+
+	spans := s.ScanLine("After 4-backtick block")
+	if len(spans) != 1 || spans[0].Text != "After 4-backtick block" {
+		t.Errorf("after 4-backtick block: expected prose, got %v", spans)
+	}
+}
+
+func TestFourBacktickFenceInnerTriple(t *testing.T) {
+	s := NewScanner()
+
+	if spans := s.ScanLine("````"); spans != nil {
+		t.Errorf("4-backtick open: expected nil, got %v", spans)
+	}
+	// A triple-backtick line inside must NOT close the block.
+	if spans := s.ScanLine("```"); spans != nil {
+		t.Errorf("inner triple backtick: expected nil (body), got %v", spans)
+	}
+	if spans := s.ScanLine("````"); spans != nil {
+		t.Errorf("4-backtick close: expected nil, got %v", spans)
+	}
+
+	spans := s.ScanLine("prose after")
+	if len(spans) != 1 || spans[0].Text != "prose after" {
+		t.Errorf("after block: expected prose, got %v", spans)
+	}
+}
+
 func TestInlineCode(t *testing.T) {
 	s := NewScanner()
 	// Skip frontmatter


### PR DESCRIPTION
## Summary

- Fix `codeFenceOpen` in `tools/lint/scanner.go` to count and return the full run of leading backtick or tilde characters instead of always returning a hardcoded 3-character string (`"` + "```" + `"` or `"~~~"`)
- A code block opened with 4+ backticks (valid MDX for demonstrating triple-backtick examples) now stores the correct closing sentinel, so the block closes properly instead of leaking all subsequent content as suppressed code
- Add `TestFourBacktickFence` and `TestFourBacktickFenceInnerTriple` to `scanner_test.go` to guard the open/close cycle and prevent inner triple-backtick lines from incorrectly terminating a 4-backtick block
- Add integration test case in `rules_test.go` confirming `--` inside a 4-backtick code block is not flagged as a violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)