### PR TITLE
fix(api): correct PyYAML import check in pull-stainless.sh

### DIFF
--- a/api/pull-stainless.sh
+++ b/api/pull-stainless.sh
@@ -43,7 +43,7 @@ if ! command -v python3 >/dev/null 2>&1; then
     echo "Python 3 is required but not installed"
     exit 1
 fi
-if ! python3 -c "import pyyaml" 2>/dev/null; then
+if ! python3 -c "import yaml" 2>/dev/null; then
     echo "Installing pyyaml..."
     if command -v pip3 >/dev/null 2>&1; then
         python3 -m pip install pyyaml types-pyyaml


### PR DESCRIPTION
## Summary

- Line 46 of `api/pull-stainless.sh` used `python3 -c "import pyyaml"` to check whether PyYAML is installed. PyYAML's importable module name is `yaml`, not `pyyaml`, so this check always raised `ModuleNotFoundError` and pip reinstalled the package on every invocation.
- Changed the check to `import yaml` so the guard works correctly: pip only runs when PyYAML is genuinely absent.
- The pip install command (`python3 -m pip install pyyaml types-pyyaml`) uses the correct PyPI package name and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)