### PR TITLE
fix(docs): correct warning direction and path placeholders in provision.mdx

### DIFF
--- a/docs/learn/devices/provision.mdx
+++ b/docs/learn/devices/provision.mdx
@@ -153,7 +153,7 @@ curl -fsSL https://raw.githubusercontent.com/mirurobotics/agent/main/scripts/ins
 ```
 
 <Info>
-  You'll need to replace `<path/to/miru-agent_<version>_<architecture>.deb>` with the actual path to the package.
+  You'll need to replace `/path/to/miru-agent_<version>_<architecture>.deb` with the actual path to the package.
 </Info>
 
 **Dashboard**

--- a/docs/learn/devices/provision.mdx
+++ b/docs/learn/devices/provision.mdx
@@ -169,9 +169,9 @@ This will give you an installation command similar to the following.
 curl -fsSL https://raw.githubusercontent.com/mirurobotics/agent/main/scripts/install/install.sh | \
 env MIRU_ACTIVATION_TOKEN=<activation-token> \
 sh -s -- \
---from-pkg=</path/to/agent.deb>
+--from-pkg=/path/to/agent.deb
 ```
 
 <Warning>
-  Do not copy the example command below. It will not work because it lacks the required activation token. Instead, follow the steps listed above.
+  Do not copy the example command above. It will not work because it lacks the required activation token. Instead, follow the steps listed above.
 </Warning>


### PR DESCRIPTION
## Summary

- Fixed `<Warning>` block text: changed "Do not copy the example command **below**" to "**above**" — the example command appears above the warning, not below
- Fixed malformed `--from-pkg` path in the dashboard example command: `</path/to/agent.deb>` (stray `<` made it look like an HTML closing tag) → `/path/to/agent.deb`
- Fixed `<Info>` block placeholder: removed outer angle brackets from `` `<path/to/miru-agent_<version>_<architecture>.deb>` `` to match the code block above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)