### PR TITLE
fix(docs): correct sync endpoint path in agent architecture diagram

### DIFF
--- a/docs/developers/agent/architecture.mdx
+++ b/docs/developers/agent/architecture.mdx
@@ -91,7 +91,7 @@ sequenceDiagram
     participant L as On-Device App
     participant A as Agent
 
-    L->>A: POST /sync
+    L->>A: POST /device/sync
     Note over A: Sync
     A-->>L: 200 OK (sync result)
 ```


### PR DESCRIPTION
## Summary

- Corrects the mermaid sequence diagram in the agent architecture page (`docs/developers/agent/architecture.mdx`)
- The diagram showed `POST /sync` as the endpoint for manually triggering a device sync from an on-device application; the correct Device API endpoint is `POST /device/sync`
- A developer following this diagram would have called the wrong URL and received a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)