### PR TITLE
docs(deployments): add 'removing' activity status

### DIFF
--- a/docs/learn/deployments.mdx
+++ b/docs/learn/deployments.mdx
@@ -47,6 +47,7 @@ import DeploymentStatus from '/snippets/deployments/status.mdx';
   - `drifted`
   - `queued`
   - `deployed`
+  - `removing`
   - `archived`
 
 </ParamField>
@@ -67,7 +68,7 @@ import DeploymentStatus from '/snippets/deployments/status.mdx';
 
   <DeploymentStatus />
 
-  Enum: `staged`, `drifted`, `queued`, `deployed`, `archived`, `failed`, `retrying`
+  Enum: `staged`, `drifted`, `queued`, `deployed`, `removing`, `archived`, `failed`, `retrying`
 </ParamField>
 
 <ParamField path="parent" type="Deployment">
@@ -163,7 +164,7 @@ The activity status is the _last known_ state of a deployment.
 
 We use _the last known state_ intentionally—poor network connectivity can prevent devices from immediately syncing their activity state with the cloud. In practice, this isn't too common. However, it's still a critical point to keep in mind.
 
-There are five possible activity states for a deployment.
+There are six possible activity states for a deployment.
 
 | Activity Status | Description                                                                                                                     |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -171,6 +172,7 @@ There are five possible activity states for a deployment.
 | `drifted`       | Deployment has [drifted](/docs/learn/releases/staging-area#deployment-drift) and needs to be reviewed                           |
 | `queued`        | Deployment is waiting for the device to be <Tooltip tip={ONLINE_TOOLTIP.tip} cta={ONLINE_TOOLTIP.cta} href={ONLINE_TOOLTIP.href}>online</Tooltip> so it can be delivered to the device |
 | `deployed`      | Deployment has been delivered to the device, and its configurations are available for consumption                               |
+| `removing`      | Deployment's configurations are being removed from the device                                                                  |
 | `archived`      | Deployment is available for historical reference, but can never be deployed again                                               |
 
 **With Staging**
@@ -182,14 +184,14 @@ During the review phase, a staged deployment may [drift](/docs/learn/releases/st
 <img src="https://assets.mirurobotics.com/docs/v03/images/deployments/activity-status-review.light.svg" alt="Deployment activity status during review phase" className="block dark:hidden" />
 <img src="https://assets.mirurobotics.com/docs/v03/images/deployments/activity-status-review.dark.svg" alt="Deployment activity status during review phase" className="hidden dark:block" />
 
-Once the deployment is approved, it enters the deployment phase. The deployment is queued for delivery to the device, delivered, and eventually archived.
+Once the deployment is approved, it enters the deployment phase. The deployment is queued for delivery to the device, delivered, and eventually removed and archived.
 
 <img src="https://assets.mirurobotics.com/docs/v03/images/deployments/activity-status-staging.light.svg" alt="Deployment activity status during deployment phase" className="block dark:hidden" />
 <img src="https://assets.mirurobotics.com/docs/v03/images/deployments/activity-status-staging.dark.svg" alt="Deployment activity status during deployment phase" className="hidden dark:block" />
 
 **Without Staging**
 
-Deployments which are immediately deployed and skip the `staged` state have a simpler lifecycle. They simply go through the primary deployment lifecycle from `queued` to `archived`.
+Deployments which are immediately deployed and skip the `staged` state have a simpler lifecycle. They simply go through the primary deployment lifecycle from `queued` to `archived`, passing through `removing` when being taken off the device.
 
 <img src="https://assets.mirurobotics.com/docs/v03/images/deployments/activity-status-no-staging.light.svg" alt="Deployment activity status without staging" className="block dark:hidden" />
 <img src="https://assets.mirurobotics.com/docs/v03/images/deployments/activity-status-no-staging.dark.svg" alt="Deployment activity status without staging" className="hidden dark:block" />

--- a/docs/learn/deployments.mdx
+++ b/docs/learn/deployments.mdx
@@ -172,7 +172,7 @@ There are six possible activity states for a deployment.
 | `drifted`       | Deployment has [drifted](/docs/learn/releases/staging-area#deployment-drift) and needs to be reviewed                           |
 | `queued`        | Deployment is waiting for the device to be <Tooltip tip={ONLINE_TOOLTIP.tip} cta={ONLINE_TOOLTIP.cta} href={ONLINE_TOOLTIP.href}>online</Tooltip> so it can be delivered to the device |
 | `deployed`      | Deployment has been delivered to the device, and its configurations are available for consumption                               |
-| `removing`      | Deployment's configurations are being removed from the device                                                                  |
+| `removing`      | Deployment's configurations are being removed from the device                                                                   |
 | `archived`      | Deployment is available for historical reference, but can never be deployed again                                               |
 
 **With Staging**

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "serve-static": ">=1.16.0",
       "socket.io-parser": ">=4.2.6",
       "tar": ">=6.2.1 <7",
-      "zod": "3.24.0"
+      "zod": "3.24.0",
+      "follow-redirects": ">=1.16.0"
     },
     "auditConfig": {
       "ignoreCves": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   socket.io-parser: '>=4.2.6'
   tar: '>=6.2.1 <7'
   zod: 3.24.0
+  follow-redirects: '>=1.16.0'
 
 importers:
 
@@ -2176,8 +2177,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -6302,7 +6303,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7274,7 +7275,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:

--- a/snippets/components/deployments/statuses.jsx
+++ b/snippets/components/deployments/statuses.jsx
@@ -21,3 +21,9 @@ export const DEPLOYED_TOOLTIP = {
     cta: "Learn more",
     href: "/docs/learn/deployments#activity-status"
 };
+
+export const REMOVING_TOOLTIP = {
+    tip: "Deployment's configurations are being removed from the device",
+    cta: "Learn more",
+    href: "/docs/learn/deployments#activity-status"
+};

--- a/snippets/deployments/status.mdx
+++ b/snippets/deployments/status.mdx
@@ -9,4 +9,5 @@ Below are examples of status values for different activities and error states.
 | `staged`        | `none`       | `staged`   |
 | `deployed`      | `none`       | `deployed` |
 | `queued`        | `retrying`   | `retrying` |
+| `removing`      | `none`       | `removing` |
 | `archived`      | `failed`     | `failed`   |


### PR DESCRIPTION
## Summary

- Adds the `removing` deployment activity status to the learn/deployments documentation, status merging snippet, and deployment statuses tooltip component
- `removing` represents the transitional state where a deployment's configurations are being removed from the device (between `deployed` and `archived`)
- The platform API (tetons) intentionally does not surface this status — no changes to the platform API spec
- The device API v0.2.1 already includes `removing` — no changes needed there

## Changed files
- `docs/learn/deployments.mdx` — enum lists, activity status table (five→six states), merged status enum, lifecycle text
- `snippets/deployments/status.mdx` — added `removing` example row to status merging table
- `snippets/components/deployments/statuses.jsx` — added `REMOVING_TOOLTIP` export

## Note
The lifecycle SVG diagrams (hosted on `assets.mirurobotics.com`) still show `deployed` → `archived` without the `removing` intermediate state. These should be updated separately.

## Test plan
- [ ] Verify the deployments learn page renders correctly with the new `removing` row in the activity status table
- [ ] Verify the status merging snippet renders the new example row
- [ ] Confirm no broken links or rendering issues on pages that import the updated snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)