### PR TITLE
fix(docs): replace /latest/ API links with PlatformApiLink component

### DIFF
--- a/docs/developers/agent/versions.mdx
+++ b/docs/developers/agent/versions.mdx
@@ -4,8 +4,8 @@ title: "Versions"
 
 import { CardNewTab } from '/snippets/components/card.jsx';
 import { LinkNewTab } from '/snippets/components/link.jsx';
-import { SupportedBadge, DeprecatedBadge, EndOfLifeBadge } from '/snippets/components/support.jsx';
 import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { SupportedBadge, DeprecatedBadge, EndOfLifeBadge } from '/snippets/components/support.jsx';
 
 The Miru Agent follows [semantic versioning](https://semver.org/) for its releases. 
 

--- a/docs/developers/agent/versions.mdx
+++ b/docs/developers/agent/versions.mdx
@@ -5,6 +5,7 @@ title: "Versions"
 import { CardNewTab } from '/snippets/components/card.jsx';
 import { LinkNewTab } from '/snippets/components/link.jsx';
 import { SupportedBadge, DeprecatedBadge, EndOfLifeBadge } from '/snippets/components/support.jsx';
+import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
 
 The Miru Agent follows [semantic versioning](https://semver.org/) for its releases. 
 
@@ -66,7 +67,7 @@ miru-agent --version
 
 **Platform API**
 
-To check the agent version from the Platform API, query the <LinkNewTab href="/docs/references/platform-api/latest/endpoints/devices/list#query-parameters">list devices</LinkNewTab> endpoint and <LinkNewTab href="/docs/developers/platform-api/query-params/filtering">filter</LinkNewTab> by the `agent_version` field.
+To check the agent version from the Platform API, query the <PlatformApiLink endpoint="devices/list#query-parameters" newTab>list devices</PlatformApiLink> endpoint and <LinkNewTab href="/docs/developers/platform-api/query-params/filtering">filter</LinkNewTab> by the `agent_version` field.
 
 ## Support policy
 

--- a/docs/developers/platform-api/query-params/expansions.mdx
+++ b/docs/developers/platform-api/query-params/expansions.mdx
@@ -2,6 +2,8 @@
 title: "Expansions"
 ---
 
+import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+
 The Miru API uses expansions to retrieve related objects in a single request rather than making multiple API calls. This simplifies code and minimizes the number of API calls.
 
 Response objects only include the core fields by default. Related objects (such as the device associated with a deployment) are included with their IDs, but not their complete object data. Using the `expand` query parameter, you can include related objects directly in the response.
@@ -12,7 +14,7 @@ Expansions are powerful but add latency. As such, they should be used strategica
 
 Many response objects reference objects that are not included in the default response.
 
-For example, a [deployment](/docs/references/platform-api/latest/endpoints/deployments/get) has the following default response structure:
+For example, a <PlatformApiLink endpoint="deployments/get">deployment</PlatformApiLink> has the following default response structure:
 
 ```json
 {
@@ -34,8 +36,8 @@ The `device`, `release`, and `config_instances` objects are not included in the 
 
 To retrieve the device for a given deployment, you could make two separate requests:
 
-- First, fetch the [**deployment**](/docs/references/platform-api/latest/endpoints/deployments/get) using its ID (assuming you already know it).
-- Then, having obtained the **`device_id`** from the deployment response, fetch the [**device**](/docs/references/platform-api/latest/endpoints/devices/get) using the device ID.
+- First, fetch the <PlatformApiLink endpoint="deployments/get"><strong>deployment</strong></PlatformApiLink> using its ID (assuming you already know it).
+- Then, having obtained the **`device_id`** from the deployment response, fetch the <PlatformApiLink endpoint="devices/get"><strong>device</strong></PlatformApiLink> using the device ID.
 
 This is workable but adds both latency and complexity to your code. A better approach is to use the `expand` parameter to include the `device` object directly in the deployment response, avoiding a second request.
 
@@ -205,7 +207,7 @@ When expanding nested fields, there's no need to expand the parent field. Since 
 
 ### Items
 
-When listing deployments, you can expand fields in the same way you would for a single deployment. By default, [listing deployments](/docs/references/platform-api/latest/endpoints/deployments/list) returns the following response structure.
+When listing deployments, you can expand fields in the same way you would for a single deployment. By default, <PlatformApiLink endpoint="deployments/list">listing deployments</PlatformApiLink> returns the following response structure.
 
 ```json
 {

--- a/docs/developers/platform-api/query-params/filtering.mdx
+++ b/docs/developers/platform-api/query-params/filtering.mdx
@@ -2,15 +2,17 @@
 title: "Filtering"
 ---
 
+import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+
 All list endpoints in the Miru API support filtering to help you retrieve specific resources.
 
-For example, when [listing devices](/docs/references/platform-api/latest/endpoints/devices/list), you can filter by `id`, `name`, and other fields.
+For example, when <PlatformApiLink endpoint="devices/list">listing devices</PlatformApiLink>, you can filter by `id`, `name`, and other fields.
 
 ## Single value filters
 
 Each list endpoint supports its own set of filter names. To see the filters supported by a specific endpoint, look for query parameters in the **Query Parameters** section containing _filter by_ in their description.
 
-`id` is a common filter amongst all list endpoints. It allows you to filter by a resource's unique identifier. For example, when listing devices, you can filter by the [**device id**](/docs/references/platform-api/latest/endpoints/devices/list#parameter-id) using **`id=<device-id>`** in the request URL.
+`id` is a common filter amongst all list endpoints. It allows you to filter by a resource's unique identifier. For example, when listing devices, you can filter by the <PlatformApiLink endpoint="devices/list#parameter-id"><strong>device id</strong></PlatformApiLink> using **`id=<device-id>`** in the request URL.
 
 The following uses the `id=dvc_123` filter to include only the device with the `dvc_123` `id`:
 
@@ -21,7 +23,7 @@ curl --request GET \
   --header 'Miru-Version: 2026-03-09.tetons'
 ```
 
-Filtering by ID will return at most one resource, since IDs are unique. Other fields, like [deployment activity status](/docs/references/platform-api/latest/endpoints/deployments/list#parameter-activity-status), can return multiple results.
+Filtering by ID will return at most one resource, since IDs are unique. Other fields, like <PlatformApiLink endpoint="deployments/list#parameter-activity-status">deployment activity status</PlatformApiLink>, can return multiple results.
 
 ## Multi-value filters
 

--- a/docs/developers/platform-api/query-params/pagination.mdx
+++ b/docs/developers/platform-api/query-params/pagination.mdx
@@ -2,7 +2,9 @@
 title: "Pagination"
 ---
 
-API resources support bulk fetching through list endpoints. For example, you can [**list config instances**](/docs/references/platform-api/latest/endpoints/config-instances/list) in a workspace. At a minimum, all list endpoints accept the **`limit`** and **`offset`** query parameters.
+import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+
+API resources support bulk fetching through list endpoints. For example, you can <PlatformApiLink endpoint="config-instances/list"><strong>list config instances</strong></PlatformApiLink> in a workspace. At a minimum, all list endpoints accept the **`limit`** and **`offset`** query parameters.
 
 The Miru API paginates results to efficiently manage large datasets, returning a subset of items along with metadata to help you retrieve additional pages.
 

--- a/docs/learn/devices/manage.mdx
+++ b/docs/learn/devices/manage.mdx
@@ -4,6 +4,7 @@ title: "Manage devices"
 
 import { ONLINE_TOOLTIP, OFFLINE_TOOLTIP } from '/snippets/components/devices/statuses.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
+import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
 
 <Framed background="https://assets.mirurobotics.com/docs/v03/images/devices/background.jpeg" image="https://assets.mirurobotics.com/docs/v03/images/devices/header:list2.png" borderWidth={"24px 30px 0 30px"} innerRadius="12px 12px 0 0" outerRadius="14px" />
 
@@ -27,7 +28,7 @@ Update the desired fields, then click **Save**.
 
 **Platform API**
 
-To edit a device programmatically, use the [update device endpoint »](/docs/references/platform-api/latest/endpoints/devices/update)
+To edit a device programmatically, use the <PlatformApiLink endpoint="devices/update">update device endpoint »</PlatformApiLink>
 
 ## Ping a device
 

--- a/docs/learn/releases/manage.mdx
+++ b/docs/learn/releases/manage.mdx
@@ -3,6 +3,7 @@ title: "Manage releases"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
+import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
 
 <Framed background="https://assets.mirurobotics.com/docs/v03/images/releases/background.jpeg" image="https://assets.mirurobotics.com/docs/v03/images/releases/header:overview.png" borderWidth="28px" />
 
@@ -20,7 +21,7 @@ To view a release and its schemas, click into the release from the releases page
 
 **Platform API**
 
-To retrieve a release programmatically, use the [get release endpoint »](/docs/references/platform-api/latest/endpoints/releases/get)
+To retrieve a release programmatically, use the <PlatformApiLink endpoint="releases/get">get release endpoint »</PlatformApiLink>
 
 ## Duplicate a release
 

--- a/snippets/components/platform-api-link.jsx
+++ b/snippets/components/platform-api-link.jsx
@@ -1,0 +1,16 @@
+import { PLATFORM_API_LATEST_VERSION } from '/snippets/constants/platform-api.jsx';
+
+/**
+ * Link to a Platform API endpoint using the latest API version.
+ *
+ * @param {string} endpoint - Path after /endpoints/, e.g. "deployments/get" or "devices/list#parameter-id"
+ * @param {boolean} [newTab] - Open link in a new tab
+ * @param {React.ReactNode} children - Link text
+ */
+export const PlatformApiLink = ({ endpoint, newTab, children }) => {
+  const href = `/docs/references/platform-api/${PLATFORM_API_LATEST_VERSION}/endpoints/${endpoint}`;
+  if (newTab) {
+    return <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>;
+  }
+  return <a href={href}>{children}</a>;
+};

--- a/snippets/constants/platform-api.jsx
+++ b/snippets/constants/platform-api.jsx
@@ -1,0 +1,6 @@
+/**
+ * The latest Platform API version used for documentation links.
+ * Update this value when a new API version is released — all
+ * PlatformApiLink references will point to the new version automatically.
+ */
+export const PLATFORM_API_LATEST_VERSION = "2026-03-09";


### PR DESCRIPTION
## Summary
- Introduces a `PLATFORM_API_LATEST_VERSION` constant (`snippets/constants/platform-api.jsx`) as a single source of truth for the latest Platform API version.
- Adds a `<PlatformApiLink>` component (`snippets/components/platform-api-link.jsx`) that builds endpoint URLs from the constant.
- Replaces all 11 hardcoded `/latest/` endpoint links across 6 MDX files with the new component.

## Motivation
Mintlify's link checker validates links statically and doesn't follow the `/latest/` → `/2026-03-09/` redirect defined in `docs.json`. This causes 10 false-positive broken link errors on every build. Using the component resolves the links directly against the actual version, and when a new API version ships, only the constant needs updating.

## Test plan
- [ ] Run `mintlify dev` and verify no broken link warnings
- [ ] Spot-check links in expansions, filtering, pagination, manage devices, manage releases, and agent versions pages
- [ ] Confirm links open to the correct API reference endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)