### PR TITLE
refactor(workflows): use Waterfall Promoter Bot app token for deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
           - production
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
@@ -29,11 +29,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.WATERFALL_APP_ID }}
+          private-key: ${{ secrets.WATERFALL_APP_PRIVATE_KEY }}
+
       - name: Check out main with full history
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Deploy ${{ inputs.ref }} → ${{ inputs.environment }}
         run: ./scripts/deploy.sh "${{ inputs.ref }}" "${{ inputs.environment }}"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "pnpm": {
     "overrides": {
       "axios": ">=1.15.0",
-      "basic-ftp": ">=5.2.2",
+      "basic-ftp": ">=5.3.0",
       "body-parser": ">=1.20.3",
       "cookie": ">=0.7.0",
       "express": ">=4.20.0 <5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   axios: '>=1.15.0'
-  basic-ftp: '>=5.2.2'
+  basic-ftp: '>=5.3.0'
   body-parser: '>=1.20.3'
   cookie: '>=0.7.0'
   express: '>=4.20.0 <5'
@@ -1454,8 +1454,8 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  basic-ftp@5.2.2:
-    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
+  basic-ftp@5.3.0:
+    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
     engines: {node: '>=10.0.0'}
 
   better-opn@3.0.2:
@@ -6377,7 +6377,7 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  basic-ftp@5.2.2: {}
+  basic-ftp@5.3.0: {}
 
   better-opn@3.0.2:
     dependencies:
@@ -7416,7 +7416,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.2
+      basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Replace the default `GITHUB_TOKEN` (`contents: write`) with a scoped token from the Waterfall Promoter Bot GitHub App in the deploy workflow
- Adds `actions/create-github-app-token` step before checkout, passes the token to `actions/checkout` so `git push` in `deploy.sh` uses the app's identity
- Downgrades workflow-level permissions to `contents: read` since write access comes from the app token

## Prerequisites
- `WATERFALL_APP_ID` must be set as a repository variable (value: `3415800`)
- `WATERFALL_APP_PRIVATE_KEY` must be set as a repository secret (the app's `.pem` private key)

## Test plan
- [ ] Verify `WATERFALL_APP_ID` variable and `WATERFALL_APP_PRIVATE_KEY` secret are configured on the `docs` repo
- [ ] Trigger a deploy to staging and confirm the push succeeds with the app token

🤖 Generated with [Claude Code](https://claude.com/claude-code)