### PR TITLE
refactor(workflows): rename deploy to promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,11 +1,11 @@
-name: Deploy
-run-name: Deploy ${{ inputs.ref }} → ${{ inputs.environment }} (by @${{ github.actor }})
+name: Promote
+run-name: Promote ${{ inputs.ref }} → ${{ inputs.environment }} (by @${{ github.actor }})
 
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref to deploy (tag, commit SHA, or branch). Must be reachable from main.'
+        description: 'Git ref to promote (tag, commit SHA, or branch). Must be reachable from main.'
         required: true
         type: string
         default: main
@@ -22,8 +22,8 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: Deploy ${{ inputs.ref }} → ${{ inputs.environment }}
+  promote:
+    name: Promote ${{ inputs.ref }} → ${{ inputs.environment }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     timeout-minutes: 10
@@ -43,5 +43,5 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Deploy ${{ inputs.ref }} → ${{ inputs.environment }}
-        run: ./scripts/deploy.sh "${{ inputs.ref }}" "${{ inputs.environment }}"
+      - name: Promote ${{ inputs.ref }} → ${{ inputs.environment }}
+        run: ./scripts/promote.sh "${{ inputs.ref }}" "${{ inputs.environment }}"

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -9,10 +9,10 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") <ref> <environment>
 
-Deploy a git ref to a target environment branch.
+Promote a git ref to a target environment branch.
 
 Arguments:
-  ref           Git ref to deploy (tag, commit SHA, or branch).
+  ref           Git ref to promote (tag, commit SHA, or branch).
                 Must be reachable from main.
   environment   Target environment (staging, uat, production).
 
@@ -61,7 +61,7 @@ if ! sha=$(git rev-parse --verify "${ref}^{commit}" 2>/dev/null); then
 fi
 
 if ! git merge-base --is-ancestor "$sha" origin/main; then
-  echo "::error::Commit ${sha} is not reachable from main. Only code merged to main can be deployed."
+  echo "::error::Commit ${sha} is not reachable from main. Only code merged to main can be promoted."
   exit 1
 fi
 
@@ -105,14 +105,14 @@ fi
 # ---------------------------------------------------------------------------
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {
-    echo "### Deploy ${ref} → ${environment}"
+    echo "### Promote ${ref} → ${environment}"
     echo ""
     echo "- **Ref:** \`${ref}\` → \`${sha}\`"
-    echo "- **Previous ${environment} SHA:** \`${target_sha:-"(none — first deploy)"}\`"
+    echo "- **Previous ${environment} SHA:** \`${target_sha:-"(none — first promote)"}\`"
     if [[ "${noop}" == "true" ]]; then
       echo "- **Result:** no-op"
     else
-      echo "- **Result:** deployed"
+      echo "- **Result:** promoted"
     fi
   } >> "$GITHUB_STEP_SUMMARY"
 fi


### PR DESCRIPTION
## Summary

- Rename `.github/workflows/deploy.yml` → `promote.yml` and `scripts/deploy.sh` → `promote.sh`
- Update all internal references: job/step names, usage text, error messages, and step summaries
- "Deploy" implied the workflow performs a deployment; "promote" accurately describes pushing a verified ref to an environment branch

## Context

Follow-up to PR #57 and #59. The original Milestone 1 used "promote" terminology, Milestone 2 renamed to "deploy", and this PR restores "promote" since it better describes the operation (promoting a ref, not deploying an application).

## Test plan

- [x] `./scripts/preflight.sh` passes clean
- [x] Full rename verified — no stale "deploy" references remain in either file
- [x] Cross-reference check — no other files in the repo reference the old filenames
- [ ] Post-merge: `gh workflow run promote.yml -f ref=main -f environment=staging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)