### PR TITLE
feat(ci): skip custom linter jobs when tools/lint/ unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ on:
   workflow_call:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      custom-linter: ${{ steps.filter.outputs.custom-linter }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            custom-linter:
+              - 'tools/lint/**'
+
   lint:
     runs-on: ubuntu-latest
 
@@ -74,6 +90,8 @@ jobs:
         run: bats pub/scripts/agent/check-miru-access_test.bats
 
   lint-custom-linter:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.custom-linter == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -91,6 +109,8 @@ jobs:
         run: ./tools/lint/scripts/lint.sh
 
   test-custom-linter:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.custom-linter == 'true'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add a `changes` detection job using `dorny/paths-filter@v4.0.1` to check whether `tools/lint/**` was modified
- `lint-custom-linter` and `test-custom-linter` jobs now only run on PRs that touch the linter source
- Pushes to environment branches (`main`, `staging`, `uat`, `production`) and `workflow_call` always run the full suite

Most PRs touch documentation (MDX, configs), not Go linter code. This avoids spinning up Go toolchain runners (~60s each) on PRs that can't affect linter behavior.

## Test plan

- [x] `./scripts/preflight.sh` passes clean
- [x] Workflow YAML is well-formed (validated by GitHub on push)
- [ ] PR that only touches docs — custom linter jobs should be skipped
- [ ] PR that touches `tools/lint/` — custom linter jobs should run
- [ ] Push to `main` — custom linter jobs should always run

🤖 Generated with [Claude Code](https://claude.com/claude-code)