### PR TITLE
Remove branch from promote workflow ref documentation

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref to promote (tag, commit SHA, or branch). Must be reachable from main.'
+        description: 'Git ref to promote (tag or commit SHA). Must be reachable from main.'
         required: true
         type: string
         default: main

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -12,7 +12,7 @@ Usage: $(basename "$0") <ref> <environment>
 Promote a git ref to a target environment branch.
 
 Arguments:
-  ref           Git ref to promote (tag, commit SHA, or branch).
+  ref           Git ref to promote (tag or commit SHA).
                 Must be reachable from main.
   environment   Target environment (staging, uat, production).
 


### PR DESCRIPTION
## Summary
Updated documentation in the promote workflow and script to clarify that only tags and commit SHAs are supported as git refs, removing the mention of branches.

## Key Changes
- Updated `.github/workflows/promote.yml` workflow input description to remove "branch" from the list of accepted ref types
- Updated `scripts/promote.sh` usage documentation to remove "branch" from the list of accepted ref types

## Details
The changes align the documentation with the actual supported functionality of the promote workflow. Both the GitHub Actions workflow input and the shell script help text now consistently indicate that only tags and commit SHAs can be promoted, not arbitrary branches.

https://claude.ai/code/session_016N2WGzqDz9YNdoELxYwcZq