### PR TITLE
feat: add CLI v0.10.1 changelog

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -10,6 +10,10 @@ import { Dropdown } from '/snippets/components/api-dropdown.jsx';
 
 *May 17, 2026*
 
+## Features
+
+- Config types referenced in schema annotations are now automatically created if they do not yet exist instead of throwing an error
+
 ## Fixes
 
 - Don't rewrite `~/.miru/settings.json` on read-only commands when no defaults need to be applied

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -6,6 +6,17 @@ description: "Changelog and migration steps for the Miru CLI"
 
 import { Dropdown } from '/snippets/components/api-dropdown.jsx';
 
+# v0.10.1
+
+*May 17, 2026*
+
+## Fixes
+
+- Don't rewrite `~/.miru/settings.json` on read-only commands when no defaults need to be applied
+- Fix the install-docs link printed in the CLI's update-available notification
+
+---
+
 # v0.10.0
 
 *April 12, 2026*


### PR DESCRIPTION
## Summary
- Adds the `v0.10.1` entry to `docs/changelog/cli.mdx`, dated 2026-05-17.
- Covers the two user-facing fixes in `cli-private` since `v0.10.0`:
  - `ConfigStore.PopulateDefaults` no longer rewrites `~/.miru/settings.json` on read-only commands when nothing changed (mirurobotics/cli-private#59).
  - Corrects the install-docs URL printed in the CLI's update-available notification (mirurobotics/cli-private#50).

The remaining 20+ commits in `cli-private` since `v0.10.0` are CI, build, dependency, and lint-tooling changes with no user-facing impact, so they are intentionally omitted. The `.deb` / apt-repository publish work (cli-private#39) is already covered by the apt-repository docs.

Note: `v0.10.1` has not yet been tagged (currently at `v0.10.1-alpha.9`). The date may need to be updated when the release actually ships.

## Test plan
- [ ] `pnpm lint` / Mintlify build is clean
- [ ] Preview renders the new entry above `v0.10.0` with the existing horizontal-rule separator pattern
- [ ] Date matches the actual release date when `v0.10.1` is tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)