### PR TITLE
docs(changelog): fix accuracy, clarity, and structure issues

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -51,7 +51,7 @@ The `instance_filepath` annotation has been updated to be an absolute file syste
 
 The default instance file path has been updated from `/srv/miru/config_instances/{config-type-slug}.json` to `/srv/miru/configs/{config-type-slug}.json`.
 
-We recommend adding the instance file path annotation to maintain the same default file path as before.
+We recommend adding the instance file path annotation pointing at the previous default location, `/srv/miru/config_instances/{config-type-slug}.json`, to preserve the old path. For example, for the `mobility` config type:
 
 ```diff
 # JSON Schema

--- a/docs/changelog/platform-api.mdx
+++ b/docs/changelog/platform-api.mdx
@@ -75,8 +75,8 @@ The `rainier` release introduces a provisioning-token flow that replaces the act
   1. Expand the `current_deployment` field on a device.
 
   ```diff
-    GET /device
-  + GET /device?expand=current_deployment
+    GET /devices
+  + GET /devices?expand=current_deployment
   ```
 
   2. Expand the `current_release` field on a device.

--- a/docs/changelog/product.mdx
+++ b/docs/changelog/product.mdx
@@ -119,7 +119,7 @@ import { Separator } from '/snippets/components/separator.jsx';
     <LazyVideo
         alt="Screen recording of comparing devices"
         className="aspect-video rounded-xl"
-        src="https://assets.mirurobotics.com/docs/changelog/26-10-04/compare-devices.mp4"
+        src="https://assets.mirurobotics.com/docs/changelog/26-04-10/compare-devices.mp4"
     />
 
     ### YAML Support
@@ -131,7 +131,7 @@ import { Separator } from '/snippets/components/separator.jsx';
     deployments.
 
     <Framed 
-        image="https://assets.mirurobotics.com/docs/changelog/26-10-04/yaml-support.png"
+        image="https://assets.mirurobotics.com/docs/changelog/26-04-10/yaml-support.png"
         borderWidth="0px"
         innerRadius="8px"
     />
@@ -152,7 +152,7 @@ import { Separator } from '/snippets/components/separator.jsx';
       instead of processing everything
 
     <Framed 
-        image="https://assets.mirurobotics.com/docs/changelog/26-10-04/agent-sse.png"
+        image="https://assets.mirurobotics.com/docs/changelog/26-04-10/agent-sse.png"
         borderWidth="0px"
         innerRadius="8px"
     />
@@ -660,9 +660,6 @@ import { Separator } from '/snippets/components/separator.jsx';
 
     [Read the full documentation »](/learn/schemas/languages/overview)
 
-</Update>
-
-<Update label="December 4, 2025">
     ## Workspace Invitations
 
     You can now invite team members to your workspace and manage their roles. This 

--- a/docs/changelog/product.mdx
+++ b/docs/changelog/product.mdx
@@ -660,6 +660,9 @@ import { Separator } from '/snippets/components/separator.jsx';
 
     [Read the full documentation »](/learn/schemas/languages/overview)
 
+</Update>
+
+<Update label="December 4, 2025">
     ## Workspace Invitations
 
     You can now invite team members to your workspace and manage their roles. This 


### PR DESCRIPTION
## Summary

Fixes three content issues surfaced by an `audit-docs` scan of `docs/changelog`:

- **platform-api.mdx** (accuracy): the `2026-05-06.rainier` "Device query parameters" example used the singular `GET /device` for the `current_deployment` expansion. The Platform API has no singular `/device` endpoint, and sibling sub-items already use `/devices`. Corrected to `GET /devices`.
- **cli.mdx** (clarity): the v0.10.0 "Default instance file path" guidance said to add an annotation "to maintain the same default file path as before" but pointed at a hardcoded filename. Reworded to point at the slug-derived prior default `/srv/miru/config_instances/{config-type-slug}.json`, with `mobility` shown only as an example.
- **product.mdx** (freshness): the "April 10, 2026" update referenced assets under the `26-10-04` folder, inconsistent with the entry date and the repo's `yy-mm-dd` convention. Corrected to `26-04-10` (3 asset URLs).

The audit also flagged the two `December 4, 2025` `<Update>` blocks as a duplicate; that is intentional (two distinct changelogs released that day), so no change was made there.

Content-only MDX edits; no OpenAPI specs touched.

## Test plan

- [x] Go MDX prose linter (`tools/lint/`) — pass on the changed files
- [x] ESLint (`eslint-plugin-mdx`, `--max-warnings=0`) — pass
- [x] cspell — 0 issues
- [ ] Visual spot-check of the changelog pages in a Mintlify preview (asset URLs assume the `26-04-10` folder exists on the asset host)

https://claude.ai/code/session_01RKxfkEsreSuNivBV1CSq6p