### PR TITLE
docs(changelog): capitalize Control in access control title

### DIFF
--- a/docs/changelog/product.mdx
+++ b/docs/changelog/product.mdx
@@ -12,7 +12,7 @@ import { Separator } from '/snippets/components/separator.jsx';
 <div className="changelog-page">
 
 <Update label="June 23, 2026">
-    ## Access control
+    ## Access Control
 
     Workspaces now have **fine-grained access control**. Every member has a
     **user type** that sets their baseline access, plus **roles** that are applied 


### PR DESCRIPTION
One-off copy fix: capitalize the **C** in the access control changelog title (`## Access control` → `## Access Control`).

Follow-up to [#120](https://github.com/mirurobotics/docs/pull/120). Lint passes (prose linter + ESLint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)