### PR TITLE
ci: migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: read
@@ -28,7 +28,7 @@ jobs:
               - 'tools/lint/**'
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Check out repository
@@ -54,7 +54,7 @@ jobs:
         run: ./scripts/lint.sh
 
   audit:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
 
       - name: Check out repository
@@ -77,7 +77,7 @@ jobs:
         run: ./scripts/audit.sh
 
   shell-tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Check out repository
@@ -93,7 +93,7 @@ jobs:
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.custom-linter == 'true'
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -112,7 +112,7 @@ jobs:
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.custom-linter == 'true'
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   codeql:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   promote:
     name: Promote ${{ inputs.ref }} → ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     environment: ${{ inputs.environment }}
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary

Migrates all GitHub-hosted CI runners to like-for-like Blacksmith equivalents.

| Workflow | Job runner | Before | After |
| --- | --- | --- | --- |
| ci.yml | all 6 jobs | `ubuntu-latest` | `blacksmith-2vcpu-ubuntu-2404` |
| codeql-analysis.yml | analyze | `ubuntu-latest` | `blacksmith-2vcpu-ubuntu-2404` |
| promote.yml | promote | `ubuntu-latest` | `blacksmith-2vcpu-ubuntu-2404` |

`ubuntu-latest` -> 2vcpu (2-core equivalent). No 4c/8c or arm runners present. No `runs-on` expressions to resolve.

The `promote` job's special behavior comes from its environment + app token, not its runner, so the like-for-like ubuntu -> blacksmith mapping is safe.

## Note

Jobs will run on Blacksmith only once the Blacksmith GitHub App has been granted access to this repo (org-level setting). Until then, GitHub will queue jobs waiting for the Blacksmith runner labels.

Only `.github/workflows/*` changed.