### PR TITLE
fix(deps): patch js-yaml DoS via front-matter override

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "form-data": ">=4.0.6",
       "glob": ">=10.5.0",
       "js-yaml": ">=4.2.0",
-      "front-matter>js-yaml": "3.14.2",
+      "front-matter>js-yaml": "3.15.0",
       "lodash": ">=4.18.0",
       "mdast-util-to-hast": ">=13.2.1",
       "minimatch": ">=9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   form-data: '>=4.0.6'
   glob: '>=10.5.0'
   js-yaml: '>=4.2.0'
-  front-matter>js-yaml: 3.14.2
+  front-matter>js-yaml: 3.15.0
   lodash: '>=4.18.0'
   mdast-util-to-hast: '>=13.2.1'
   minimatch: '>=9.0.7'
@@ -2725,8 +2725,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -7087,7 +7087,7 @@ snapshots:
 
   front-matter@4.0.2:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
 
   fs-constants@1.0.0:
     optional: true
@@ -7750,7 +7750,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
## What

Bumps the `front-matter>js-yaml` pnpm override from `3.14.2` to `3.15.0`.

## Why

Dependabot alert [#61](https://github.com/mirurobotics/docs/security/dependabot/61) — **JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases** (medium, `js-yaml < 3.15.0`).

The vulnerable copy was the one pinned for `front-matter@4.0.2`, which requires js-yaml 3.x. `3.15.0` is the patched 3.x backport, so this is the minimal compatible fix. Every other js-yaml consumer already resolves to `4.2.0` via the top-level `js-yaml: ">=4.2.0"` override.

## Changes

- `package.json`: `front-matter>js-yaml` override `3.14.2` → `3.15.0`
- `pnpm-lock.yaml`: regenerated (`pnpm install --lockfile-only`) — only the `js-yaml@3.14.2` → `js-yaml@3.15.0` block and `front-matter`'s dependency change; no other resolutions move.

Scoped to the dependency fix only — no docs content in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786309931&installation_id=142588636&pr_number=127&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F127&signature=76c109a8dafc901d2d0291ceca3333f904f9acc5b94545fecccb7d02e7158efb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->