### PR TITLE
chore(deps): raise audit override floors and fix lint.sh on macOS bash 3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "picomatch": ">=4.0.4",
       "smol-toml": ">=1.6.1",
       "yaml": ">=2.8.3",
-      "brace-expansion": ">=5.0.8",
+      "brace-expansion": ">=5.0.9",
       "path-to-regexp": "0.1.13",
       "postcss": ">=8.5.18",
       "qs": ">=6.15.2",
@@ -44,7 +44,7 @@
       "follow-redirects": ">=1.16.0",
       "ws": ">=8.20.1",
       "adm-zip": ">=0.6.0",
-      "fast-uri": ">=3.1.4 <4",
+      "fast-uri": ">=3.1.5 <4",
       "sharp": ">=0.35.0"
     },
     "auditConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
   picomatch: '>=4.0.4'
   smol-toml: '>=1.6.1'
   yaml: '>=2.8.3'
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   path-to-regexp: 0.1.13
   postcss: '>=8.5.18'
   qs: '>=6.15.2'
@@ -34,7 +34,7 @@ overrides:
   follow-redirects: '>=1.16.0'
   ws: '>=8.20.1'
   adm-zip: '>=0.6.0'
-  fast-uri: '>=3.1.4 <4'
+  fast-uri: '>=3.1.5 <4'
   sharp: '>=0.35.0'
 
 importers:
@@ -1503,8 +1503,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2168,8 +2168,8 @@ packages:
   fast-memoize@2.5.2:
     resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -6163,7 +6163,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6334,7 +6334,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7173,7 +7173,7 @@ snapshots:
 
   fast-memoize@2.5.2: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.3.0:
     dependencies:
@@ -8617,7 +8617,7 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8:
     optional: true

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -27,16 +27,19 @@ collect_files() {
   fi
 }
 
+# Snippets are collected separately below so they lint last. The filter uses
+# an if-test, and this comment sits outside the process substitution, because
+# bash 3.2 on macOS counts every closing paren inside a substitution as the
+# one that ends it.
 mdx_targets=()
 while IFS= read -r -d '' file; do
   mdx_targets+=("${file}")
 done < <(
   collect_files "${content_root}" "*.mdx" |
     while IFS= read -r -d '' file; do
-      case "${file}" in
-        "${content_root}/snippets/"*) ;;
-        *) printf '%s\0' "${file}" ;;
-      esac
+      if [[ "${file}" != "${content_root}/snippets/"* ]]; then
+        printf '%s\0' "${file}"
+      fi
     done
 )
 while IFS= read -r -d '' file; do


### PR DESCRIPTION
## Summary

Two independent fixes, both surfaced by running `./scripts/audit.sh` locally.

### 1. Audit override floors

`./scripts/audit.sh` was failing on `main` with two high-severity advisories. Both packages already had `pnpm.overrides` entries, but each floor sat exactly one patch below the fixed release, so pnpm resolved a still-vulnerable version.

| Package | Resolved before | Advisory | Now |
| --- | --- | --- | --- |
| `fast-uri` | 3.1.4 | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer | 3.1.5 |
| `brace-expansion` | 5.0.8 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | 5.0.9 |

`fast-uri` is reached through `mint > @mintlify/cli > @mintlify/common > @asyncapi/parser > ajv`, and `brace-expansion` through `eslint > minimatch`. Both are dev/build-time dependencies, not shipped to readers. The `fast-uri` override keeps its `<4` ceiling because `ajv` depends on the v3 line; only the lower bound moved.

### 2. `scripts/lint.sh` could not run on macOS

While verifying the dependency bump, `pnpm lint` turned out to be broken on macOS and had been for a while. The MDX target filter used a `case` statement inside a `< <(...)` process substitution. Bash 3.2 — which is what Apple ships — treats the first closing paren it finds inside a substitution as the one that ends it, so the case pattern's paren aborted parsing and the script died before running a single check. CI runs bash 5 on Linux, where this parses fine, which is why it went unnoticed.

Replaced with an equivalent `if` test. The explanatory comment lives outside the substitution, because parens in a comment trip the identical bug.

## Verification

- [x] `./scripts/audit.sh` exits 0 (was exit 1). Remaining output is `1 high (1 ignored)`, the pre-existing entry covered by `auditConfig.ignoreCves`.
- [x] `pnpm-lock.yaml` resolves `fast-uri@3.1.5` and `brace-expansion@5.0.9`; lockfile diff is limited to these two packages.
- [x] `./scripts/lint.sh` now runs to completion on macOS: all four stages pass, "All documentation lint checks passed."
- [x] `./tests/test-lint.sh` exits 0.
- [x] File selection unchanged: 76 non-snippet and 74 snippet MDX files, matching the 150 cspell reports, with snippets still linted last.
- [x] `bash -n` clean across all five shell scripts in `scripts/` and `tests/`.