### PR TITLE
ci: cache Go modules for tools/lint and validate the docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Run documentation lint
         run: ./scripts/lint.sh
 
+      - name: Validate documentation build
+        run: pnpm run validate
+
   audit:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
@@ -102,6 +105,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: tools/lint/go.mod
+          cache-dependency-path: tools/lint/go.sum
 
       - name: Run Go lint on tools/lint
         env:
@@ -121,6 +125,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: tools/lint/go.mod
+          cache-dependency-path: tools/lint/go.sum
 
       - name: Run coverage gate for tools/lint
         run: ./tools/lint/scripts/covgate.sh

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "cd docs && mint dev",
     "lint": "./scripts/lint.sh",
+    "validate": "cd docs && mint validate",
     "test:lint": "./tests/test-lint.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Two unrelated CI gaps, both surfaced while investigating the failed Mintlify deploy of `73d8e05`.

**1. Go module cache never restored.** `setup-go` was configured with `go-version-file: tools/lint/go.mod` but no `cache-dependency-path`, so its cache lookup fell back to the repo root — where there is no `go.mod`. Every run of `lint-custom-linter` and `test-custom-linter` logged:

> `Restore cache failed: Dependencies file is not found in /home/runner/_work/docs/docs. Supported file pattern: go.mod`

and re-downloaded the module set from scratch. Adding `cache-dependency-path: tools/lint/go.sum` points it at the real manifest.

**2. CI never compiled the site.** The `lint` job runs prose lint, eslint-mdx, cspell and `mint openapi-check` — none of which build the docs. That made the hosted Mintlify deploy the first real build gate, which is how a bad page would reach `main` before anyone noticed. `mint validate` is Mintlify's own strict build validation (fails on warnings *and* errors) and reuses the dev dependencies the `lint` job already installs.

## Test plan

- `pnpm run validate` passes locally on `main` (~40s): `success build validation passed`
- The two `Restore cache failed` annotations should be gone from this run's `lint-custom-linter` / `test-custom-linter` jobs

Note that `lint-custom-linter` and `test-custom-linter` are gated on `tools/lint/**` changes, so on this PR they only run because the workflow itself changed — the cache fix is best confirmed on the post-merge `main` push.

## Not included

`mint broken-links` is also clean on `main` and would be cheap to add, but I left it out to keep this change to the build gate proper. Happy to fold it in if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789078413&installation_model_id=425273&pr_number=152&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F152&signature=53c986430af4f13d5be0700c4aa324d9aa11c8b14073607ae6be521c87a047a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->