### PR TITLE
docs(cli): rename Login to Authentication and document MIRU_API_KEY

### DIFF
--- a/docs/cfg-mgmt/create-a-release.mdx
+++ b/docs/cfg-mgmt/create-a-release.mdx
@@ -31,7 +31,7 @@ The CLI can be used to programmatically create releases in a [CI pipeline](/deve
 
 To create a release, the following prerequisites must be met:
 
-1. CLI installed - [install](/developers/cli/install) the Miru CLI on your development machine and authenticate using the [login](/developers/cli/login) command
+1. CLI installed - [install](/developers/cli/install) the Miru CLI on your development machine and [authenticate](/developers/cli/authentication) the CLI
 1. Local Git repository - the release's definitions must be committed to a local Git repository
 
 ## Config schemas

--- a/docs/developers/cli/authentication.mdx
+++ b/docs/developers/cli/authentication.mdx
@@ -18,7 +18,7 @@ The `login` command prompts for a token, which makes it unsuitable for anything 
 export MIRU_API_KEY=<your-api-key>
 ```
 
-No `login` is required when `MIRU_API_KEY` is set. The CLI prints a notice indicating that the key came from the environment.
+No `login` is required when `MIRU_API_KEY` is set.
 
 To create an API key, follow the instructions in the [API keys](/admin/apikeys#create-an-api-key) section. To determine which scopes the key needs, find the command you want to run in the [CLI Reference](/references/cli/release-create) and consult its **API key scopes** section.
 

--- a/docs/developers/cli/authentication.mdx
+++ b/docs/developers/cli/authentication.mdx
@@ -1,14 +1,18 @@
 ---
-title: 'Login'
+title: 'Authentication'
 ---
 
 import LoginInstructions from '/snippets/references/cli/login.mdx';
 
+The CLI supports two ways to authenticate: an interactive login for your development machine, and an API key for non-interactive use such as CI pipelines, scripts, and AI agents.
+
+## Interactive login
+
 <LoginInstructions />
 
-## API key authentication
+## API key
 
-The `login` command is interactive and prompts for a token, which makes it unsuitable for CI pipelines, scripts, and AI agents. For non-interactive use, authenticate with an API key instead by exporting the `MIRU_API_KEY` environment variable.
+The `login` command prompts for a token, which makes it unsuitable for anything non-interactive. To authenticate without a prompt, export the `MIRU_API_KEY` environment variable instead.
 
 ```bash
 export MIRU_API_KEY=<your-api-key>

--- a/docs/developers/cli/login.mdx
+++ b/docs/developers/cli/login.mdx
@@ -5,3 +5,17 @@ title: 'Login'
 import LoginInstructions from '/snippets/references/cli/login.mdx';
 
 <LoginInstructions />
+
+## API key authentication
+
+The `login` command is interactive and prompts for a token, which makes it unsuitable for CI pipelines, scripts, and AI agents. For non-interactive use, authenticate with an API key instead by exporting the `MIRU_API_KEY` environment variable.
+
+```bash
+export MIRU_API_KEY=<your-api-key>
+```
+
+No `login` is required when `MIRU_API_KEY` is set. The CLI prints a notice indicating that the key came from the environment.
+
+To create an API key, follow the instructions in the [API keys](/admin/apikeys#create-an-api-key) section. To determine which scopes the key needs, find the command you want to run in the [CLI Reference](/references/cli/release-create) and consult its **API key scopes** section.
+
+For using the CLI in a CI pipeline, see the [CI/CD guide](/developers/ci/overview).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -144,7 +144,7 @@
                 "pages": [
                   "developers/cli/overview",
                   "developers/cli/install",
-                  "developers/cli/login"
+                  "developers/cli/authentication"
                 ]
               },
               {
@@ -207,6 +207,12 @@
       {
         "product": "CLI Reference",
         "groups": [
+          {
+            "group": "Authentication",
+            "pages": [
+              "references/cli/login"
+            ]
+          },
           {
             "group": "Releases",
             "pages": [
@@ -418,6 +424,10 @@
     {
       "source": "/developers/agent/file-permissions",
       "destination": "/developers/agent/filesys-access"
+    },
+    {
+      "source": "/developers/cli/login",
+      "destination": "/developers/cli/authentication"
     },
     {
       "source": "/changelogs/:slug*",

--- a/docs/references/cli/login.mdx
+++ b/docs/references/cli/login.mdx
@@ -1,0 +1,27 @@
+---
+title: "Login"
+---
+
+import LoginInstructions from "/snippets/references/cli/login.mdx";
+
+Authenticate the CLI on your development machine by storing a token locally.
+
+`login` is interactive and prompts for a token. For non-interactive use such as [CI pipelines](/developers/ci/overview), scripts, and AI agents, authenticate with the `MIRU_API_KEY` environment variable instead — see [Authentication](/developers/cli/authentication#api-key).
+
+### Usage
+
+```bash
+miru login
+```
+
+**Flags**
+
+`login` takes no flags beyond the global ones.
+
+<ParamField path="--quiet, -q" type="boolean">
+  Suppress output except errors.
+</ParamField>
+
+### Example
+
+<LoginInstructions />

--- a/docs/references/cli/login.mdx
+++ b/docs/references/cli/login.mdx
@@ -10,18 +10,4 @@ Authenticate the CLI on your development machine by storing a token locally.
 
 ### Usage
 
-```bash
-miru login
-```
-
-**Flags**
-
-`login` takes no flags beyond the global ones.
-
-<ParamField path="--quiet, -q" type="boolean">
-  Suppress output except errors.
-</ParamField>
-
-### Example
-
 <LoginInstructions />


### PR DESCRIPTION
## Why

The CLI docs had a page titled **Login** — named after a command, while readers arrive with a task: *how do I authenticate the CLI?* Two mechanisms answer that question, but the page covered only one. `MIRU_API_KEY` lived on the CI/CD pages, easy to miss.

The practical effect: anyone driving the CLI non-interactively — CI, scripts, or an AI agent — read the Login page and concluded the CLI was interactive-only.

## What

**`developers/cli/login` → `developers/cli/authentication`**, with both mechanisms as siblings:

- `## Interactive login` — the existing shared snippet, unchanged
- `## API key` — new, covering `MIRU_API_KEY`, with links to key creation, scopes, and the CI/CD guide

A separate API-key page was considered and rejected: it would leave *Login*, the obvious destination, still not mentioning the env var — the original bug, reintroduced.

Also:

- Redirect `/developers/cli/login` → `/developers/cli/authentication`
- Updated the inbound link in `cfg-mgmt/create-a-release.mdx`
- **New `references/cli/login` page** under a new Authentication group in the CLI Reference, which previously documented only `release create`
- The interactive flow stays a snippet — the quick start still imports it

## Open question

I left out any claim about **precedence** between `MIRU_API_KEY` and a token stored by a previous `login`. The v0.10.2 changelog mentions an "API key source notice when `MIRU_API_KEY` is set", which implies the env var wins, but I couldn't verify it (`mirurobotics/cli` is a distribution stub, and confirming it needs an authenticated call). Worth a sentence once confirmed.

## Testing

`pnpm lint` and `pnpm validate` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)