### PR TITLE
chore: add devcontainer config for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// Codespaces / Dev Containers configuration.
+// Format reference: https://containers.dev/implementors/json_reference/
+{
+  "name": "docs",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    // tools/lint is a Go module (go 1.25.3) and scripts/preflight.sh runs it.
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.25"
+    }
+  },
+  // Mintlify dev server plus the Go lint tool; no compilation of consequence.
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
+  // pnpm comes from the packageManager field via corepack.
+  "postCreateCommand": "corepack enable && pnpm install",
+  // `mint dev` serves the docs site here.
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "mint dev",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "unifiedjs.vscode-mdx",
+        "davidanson.vscode-markdownlint",
+        "streetsidesoftware.code-spell-checker",
+        "dbaeumer.vscode-eslint",
+        "golang.go",
+        "eamodio.gitlens",
+        "github.vscode-github-actions",
+        "github.vscode-pull-request-github",
+        "redhat.vscode-yaml",
+        "timonwong.shellcheck"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "[go]": {
+          "editor.defaultFormatter": "golang.go"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `.devcontainer/devcontainer.json` so Codespaces on this repo come up ready to run the docs site.

## What's in it

- **Image:** `mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm`.
- **Go feature (1.25):** `tools/lint` is a Go module (`go 1.25.3`) and `scripts/preflight.sh` runs both its lint and its coverage gate. A Node-only image would fail preflight inside the codespace — this is the non-obvious part of this config.
- **Features:** github-cli, go.
- **`hostRequirements`:** 4 cpus / 16gb / 32gb.
- **Ports:** 3000 forwarded and labelled for `mint dev`.
- **Extensions:** MDX, markdownlint, cSpell, ESLint, Go, GitLens, GitHub Actions/PR, YAML, shellcheck.
- **postCreate:** `corepack enable && pnpm install` — pnpm resolves from the `packageManager` field (`pnpm@10.17.0`).

No cross-repo Codespaces grants are needed — the docs build does not pull from other repos.

Editor-personal extensions (e.g. vim keybindings) are deliberately left out; those belong in each developer's VS Code Settings Sync rather than a shared repo config.

## Verification

- `./scripts/preflight.sh` — passed (lint smoke tests, Go lint + coverage, lint).
- JSONC parses cleanly with comments stripped; image tag confirmed present in the MCR tag list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789610611&installation_model_id=425273&pr_number=163&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F163&signature=028394a22dfea32d4878ad633f292dfce2f7ea3d17686a85312779f40ba8c504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->