### PR TITLE
feat: mark platform API availability on operation docs

### DIFF
--- a/docs/admin/apikeys.mdx
+++ b/docs/admin/apikeys.mdx
@@ -3,7 +3,7 @@ title: "API keys"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
-import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge } from '/snippets/components/role-badges.jsx';
 
 <Framed 
@@ -20,7 +20,7 @@ Your API keys carry many privileges, so be sure to keep them secure! Do not shar
 
 ## Create an API key  <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To create an API key, navigate to the [Secrets page](https://app.mirurobotics.com/settings/secrets) in the dashboard and click **New API Key** in the top right.
 
@@ -34,7 +34,7 @@ Once an API key has been created, it can never be retrieved again. If you lose y
 
 ## View API keys
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To view your existing API keys, navigate to the [Secrets page](https://app.mirurobotics.com/settings/secrets).
 
@@ -50,7 +50,7 @@ To see the scopes of an API key, hover over the information icon in the **Scopes
 
 ## Delete an API key  <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Deleting an API key immediately revokes it. Attempting to authenticate with a deleted API key will fail. Furthermore, deleting an API key is irreversible. Once an API key is deleted, it cannot be recovered.
 

--- a/docs/admin/apikeys.mdx
+++ b/docs/admin/apikeys.mdx
@@ -3,6 +3,7 @@ title: "API keys"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
+import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge } from '/snippets/components/role-badges.jsx';
 
 <Framed 
@@ -19,6 +20,8 @@ Your API keys carry many privileges, so be sure to keep them secure! Do not shar
 
 ## Create an API key  <AdminBadge />
 
+<DashboardOnlyBadge />
+
 To create an API key, navigate to the [Secrets page](https://app.mirurobotics.com/settings/secrets) in the dashboard and click **New API Key** in the top right.
 
 <Frame>
@@ -30,6 +33,8 @@ Provide a name for the API key, select the desired scopes, then click **Create**
 Once an API key has been created, it can never be retrieved again. If you lose your API key, you must create a new one.
 
 ## View API keys
+
+<DashboardOnlyBadge />
 
 To view your existing API keys, navigate to the [Secrets page](https://app.mirurobotics.com/settings/secrets).
 
@@ -44,6 +49,8 @@ To see the scopes of an API key, hover over the information icon in the **Scopes
 </Frame>
 
 ## Delete an API key  <AdminBadge />
+
+<DashboardOnlyBadge />
 
 Deleting an API key immediately revokes it. Attempting to authenticate with a deleted API key will fail. Furthermore, deleting an API key is irreversible. Once an API key is deleted, it cannot be recovered.
 

--- a/docs/admin/users/manage.mdx
+++ b/docs/admin/users/manage.mdx
@@ -3,6 +3,7 @@ title: "Manage members"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
+import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge } from '/snippets/components/role-badges.jsx';
 import { ROLE_TOOLTIP } from '/snippets/components/users/roles.jsx';
 import { SUSPENDED_TOOLTIP } from '/snippets/components/users/statuses.jsx';
@@ -10,6 +11,8 @@ import { SUSPENDED_TOOLTIP } from '/snippets/components/users/statuses.jsx';
 <Framed background="https://assets.mirurobotics.com/docs/v04/images/users/background.jpeg" image="https://assets.mirurobotics.com/docs/v04/images/users/members/header:page2.png" borderWidth="20px" />
 
 ## Change a member's access <AdminBadge />
+
+<DashboardOnlyBadge />
 
 To change a member's <Tooltip tip={ROLE_TOOLTIP.tip} cta={ROLE_TOOLTIP.cta} href={ROLE_TOOLTIP.href}>role</Tooltip>, first navigate to the [members](https://app.mirurobotics.com/settings/members) page.
 
@@ -26,6 +29,8 @@ Select the new role and hit **Save**.
 </Info>
 
 ## Suspend a member  <AdminBadge />
+
+<DashboardOnlyBadge />
 
 Suspending a member immediately revokes their access to the workspace and sets their status to <Tooltip tip={SUSPENDED_TOOLTIP.tip} cta={SUSPENDED_TOOLTIP.cta} href={SUSPENDED_TOOLTIP.href}>suspended</Tooltip>:
 

--- a/docs/admin/users/manage.mdx
+++ b/docs/admin/users/manage.mdx
@@ -3,7 +3,7 @@ title: "Manage members"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
-import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge } from '/snippets/components/role-badges.jsx';
 import { ROLE_TOOLTIP } from '/snippets/components/users/roles.jsx';
 import { SUSPENDED_TOOLTIP } from '/snippets/components/users/statuses.jsx';
@@ -12,7 +12,7 @@ import { SUSPENDED_TOOLTIP } from '/snippets/components/users/statuses.jsx';
 
 ## Change a member's access <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To change a member's <Tooltip tip={ROLE_TOOLTIP.tip} cta={ROLE_TOOLTIP.cta} href={ROLE_TOOLTIP.href}>role</Tooltip>, first navigate to the [members](https://app.mirurobotics.com/settings/members) page.
 
@@ -30,7 +30,7 @@ Select the new role and hit **Save**.
 
 ## Suspend a member  <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Suspending a member immediately revokes their access to the workspace and sets their status to <Tooltip tip={SUSPENDED_TOOLTIP.tip} cta={SUSPENDED_TOOLTIP.cta} href={SUSPENDED_TOOLTIP.href}>suspended</Tooltip>:
 

--- a/docs/cfg-mgmt/create-a-release.mdx
+++ b/docs/cfg-mgmt/create-a-release.mdx
@@ -3,7 +3,7 @@ title: "Create a release"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
 import CreateExistingSchemas from '/snippets/references/cli/releases/create/existing-schemas.mdx';
 import CLIFlags from '/snippets/references/cli/releases/create/flags.mdx';
 import CreateNewSchemas from '/snippets/references/cli/releases/create/new-schemas.mdx';
@@ -76,6 +76,8 @@ The `config type` annotation is the only required annotation—it's how Miru kno
 
 ## Git commit
 
+<PlatformApiBadge endpoint="git-commits/create" />
+
 When creating a release, the CLI captures the following Git metadata from the *local* Git repository where the CLI is run:
 
 | Metadata | Description |
@@ -85,14 +87,6 @@ When creating a release, the CLI captures the following Git metadata from the *l
 | **File paths** | The file paths of the schemas relative to the repository root |
 
 This metadata is then made available in the dashboard for the release, allowing you to easily trace the release's origin.
-
-**Platform API**
-
-To register a git commit programmatically, use the <PlatformApiLink endpoint="git-commits/create">create git commit endpoint »</PlatformApiLink>
-
-To retrieve a git commit programmatically, use the <PlatformApiLink endpoint="git-commits/get">get git commit endpoint »</PlatformApiLink>
-
-To list git commits programmatically, use the <PlatformApiLink endpoint="git-commits/list">list git commits endpoint »</PlatformApiLink>
 
 ### Supported Git providers
 

--- a/docs/cfg-mgmt/deploy/staging-area.mdx
+++ b/docs/cfg-mgmt/deploy/staging-area.mdx
@@ -3,7 +3,7 @@ title: "Staging area"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge, PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
 import { OperatorBadge } from '/snippets/components/role-badges.jsx';
 
 <Framed background="https://assets.mirurobotics.com/docs/v04/images/releases/background.jpeg" image="https://assets.mirurobotics.com/docs/v04/images/releases/stage/header:page.png" borderWidth="30px 0 0 48px" innerRadius="8px 0 0 0" />
@@ -41,6 +41,8 @@ Then select the **Stage** tab at the top of the page.
 </Frame>
 
 ## Stage a deployment  <OperatorBadge />
+
+<PlatformApiBadge endpoint="deployments/create" />
 
 Staging a deployment creates a new deployment in the staging area but does not deploy it
 to any devices.
@@ -98,12 +100,12 @@ list for the selected device.
   ![](https://assets.mirurobotics.com/docs/v04/images/releases/stage/staged-deployment.png)
 </Frame>
 
-**Platform API**
-
 To stage a deployment programmatically, set the `target_status` field to `staged` when
 using the <PlatformApiLink endpoint="deployments/create">create deployment endpoint »</PlatformApiLink>
 
 ## View a deployment
+
+<PlatformApiBadge endpoint="deployments/get" />
 
 To view a deployment in the staging area, select it from the list.
 
@@ -136,13 +138,9 @@ contains audit information—the author, creation date, description, etc.
   </Tab>
 </Tabs>
 
-**Platform API**
-
-To retrieve a deployment programmatically, use the <PlatformApiLink endpoint="deployments/get">get deployment endpoint »</PlatformApiLink>
-
-To list deployments programmatically, use the <PlatformApiLink endpoint="deployments/list">list deployments endpoint »</PlatformApiLink>
-
 ## Patch a deployment  <OperatorBadge />
+
+<PlatformApiBadge endpoint="deployments/create" />
 
 Patching a deployment opens the release editor with the configuration content from an
 existing staged deployment, allowing you to create a replacement staged deployment for
@@ -170,12 +168,12 @@ A dialog will appear asking for a description. Enter a description, then click
 After staging, Miru returns you to the staging area, where the updated staged deployment
 appears in the list.
 
-**Platform API**
-
 To patch a deployment programmatically, set the `parent_id` field to the deployment
 being replaced when using the <PlatformApiLink endpoint="deployments/create">create deployment endpoint »</PlatformApiLink>
 
 ## Archive a deployment  <OperatorBadge />
+
+<PlatformApiBadge endpoint="deployments/archive" />
 
 Archiving a deployment removes it from the staging area and marks it as `archived`.
 
@@ -218,11 +216,9 @@ A confirmation dialog will appear—hit **Archive** to confirm.
   ![Archive Bulk Deployments Dialog](https://assets.mirurobotics.com/docs/v04/images/releases/stage/archive-dialog:bulk.png)
 </Frame>
 
-**Platform API**
-
-To archive a deployment programmatically, use the <PlatformApiLink endpoint="deployments/archive">archive deployment endpoint »</PlatformApiLink>
-
 ## Deploy a deployment  <OperatorBadge />
+
+<PlatformApiBadge endpoint="deployments/deploy" />
 
 Deploying a deployment removes the existing deployment from the device and replaces it
 with the new deployment.
@@ -249,10 +245,6 @@ A confirmation dialog will appear. Hit **Deploy** to confirm.
   ![Deploy Bulk Deployments Dialog](https://assets.mirurobotics.com/docs/v04/images/releases/stage/deploy-dialog:bulk.png)
 </Frame>
 
-**Platform API**
-
-To deploy a deployment programmatically, use the <PlatformApiLink endpoint="deployments/deploy">deploy deployment endpoint »</PlatformApiLink>
-
 ## Deployment drift
 
 When a device receives configuration updates for its current release while having
@@ -278,6 +270,8 @@ The concept of deployment drift ensures that configuration changes aren't lost d
 migrations between releases, preventing misconfigurations.
 
 ## Review a deployment  <OperatorBadge />
+
+<PlatformApiBadge endpoint="deployments/drifts" />
 
 Reviewing a deployment is only possible when a deployment has
 [drifted](#deployment-drift) and is in the `drifted` state. Otherwise, the review button
@@ -339,8 +333,6 @@ deployments are available for historical reference but cannot be deployed.
 
 The ability to apply patches to a drifted deployment is currently unavailable, but will
 be coming soon!
-
-**Platform API**
 
 To list the deployments that have been deployed to a device since a deployment was
 staged, use the <PlatformApiLink endpoint="deployments/drifts">deployment drifts endpoint »</PlatformApiLink>

--- a/docs/cfg-mgmt/primitives/config-instances.mdx
+++ b/docs/cfg-mgmt/primitives/config-instances.mdx
@@ -5,7 +5,7 @@ title: "Config instances"
 import AgentYamlSupport from '/snippets/agent/yaml-support.mdx';
 import { ImmutableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge, PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
 import ConfigInstanceDef from '/snippets/definitions/config-instance.mdx';
 import SchemaFormats from '/snippets/schemas/formats.mdx';
 
@@ -55,24 +55,15 @@ The formats a config instance may use are determined by the schema language of i
 
 ## View a config instance
 
-**Dashboard**
+<PlatformApiBadge endpoint="config-instances/get" />
 
 Config instances are viewed from the places they appear—a device's [config editor](/cfg-mgmt/deploy/config-editor), a release's [staging area](/cfg-mgmt/deploy/staging-area#view-a-deployment), or a device's [deployment history](/cfg-mgmt/audit/device-history#view-a-config-instance).
-
-**Platform API**
-
-To retrieve a config instance programmatically, use the <PlatformApiLink endpoint="config-instances/get">get config instance endpoint »</PlatformApiLink>
-
-To list config instances programmatically, use the <PlatformApiLink endpoint="config-instances/list">list config instances endpoint »</PlatformApiLink>
 
 To download a config instance's content as a file, use the <PlatformApiLink endpoint="config-instances/download-content">download config instance content endpoint »</PlatformApiLink>
 
 ## Create a config instance
 
-**Dashboard**
+<PlatformApiBadge endpoint="config-instances/create" />
 
 Config instances are created for you whenever configs are deployed from the dashboard, such as when [staging a deployment](/cfg-mgmt/deploy/staging-area#stage-a-deployment) or deploying from a device's [config editor](/cfg-mgmt/deploy/config-editor).
 
-**Platform API**
-
-To create a config instance programmatically, use the <PlatformApiLink endpoint="config-instances/create">create config instance endpoint »</PlatformApiLink>

--- a/docs/cfg-mgmt/primitives/config-types.mdx
+++ b/docs/cfg-mgmt/primitives/config-types.mdx
@@ -4,7 +4,7 @@ title: "Config types"
 
 import { ImmutableBadge, EditableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { DashboardOnlyBadge, PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge, PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, PublisherBadge } from '/snippets/components/role-badges.jsx';
 import ConfigTypeDef from '/snippets/definitions/config-type.mdx';
 
@@ -82,7 +82,7 @@ Update the desired fields, then click **Save**.
 
 ## Delete a config type  <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Deleting a config type is irreversible. Once a config type is deleted, it cannot be recovered.
 

--- a/docs/cfg-mgmt/primitives/config-types.mdx
+++ b/docs/cfg-mgmt/primitives/config-types.mdx
@@ -4,7 +4,7 @@ title: "Config types"
 
 import { ImmutableBadge, EditableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { DashboardOnlyBadge, PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, PublisherBadge } from '/snippets/components/role-badges.jsx';
 import ConfigTypeDef from '/snippets/definitions/config-type.mdx';
 
@@ -40,19 +40,13 @@ import ConfigTypeDef from '/snippets/definitions/config-type.mdx';
 
 ## View a config type
 
-**Dashboard**
+<PlatformApiBadge endpoint="config-types/get" />
 
 To view your workspace's config types, navigate to the [Config Types page](https://app.mirurobotics.com/configs).
 
-**Platform API**
-
-To retrieve a config type programmatically, use the <PlatformApiLink endpoint="config-types/get">get config type endpoint »</PlatformApiLink>
-
-To list config types programmatically, use the <PlatformApiLink endpoint="config-types/list">list config types endpoint »</PlatformApiLink>
-
 ## Create a config type  <PublisherBadge />
 
-**Dashboard**
+<PlatformApiBadge endpoint="config-types/create" />
 
 Navigate to the [Config Types page](https://app.mirurobotics.com/configs) and click **New Config Type** in the top right corner.
 
@@ -70,13 +64,9 @@ Fill in the fields, then click **Create**.
   Config type slugs are immutable and cannot be modified after creation.
 </Warning>
 
-**Platform API**
-
-To create a config type programmatically, use the <PlatformApiLink endpoint="config-types/create">create config type endpoint »</PlatformApiLink>
-
 ## Edit a config type  <PublisherBadge />
 
-**Dashboard**
+<PlatformApiBadge endpoint="config-types/update" />
 
 Navigate to the [Config Types page](https://app.mirurobotics.com/configs), click the ellipses (...) on the config type you want to edit, and hit **Edit**.
 
@@ -90,11 +80,9 @@ Update the desired fields, then click **Save**.
   ![Edit Config Type Dialog](https://assets.mirurobotics.com/docs/v04/images/config-types/edit-dialog.png)
 </Frame>
 
-**Platform API**
-
-To edit a config type programmatically, use the <PlatformApiLink endpoint="config-types/update">update config type endpoint »</PlatformApiLink>
-
 ## Delete a config type  <AdminBadge />
+
+<DashboardOnlyBadge />
 
 Deleting a config type is irreversible. Once a config type is deleted, it cannot be recovered.
 

--- a/docs/cfg-mgmt/primitives/schemas/manage.mdx
+++ b/docs/cfg-mgmt/primitives/schemas/manage.mdx
@@ -3,20 +3,20 @@ title: "Manage schemas"
 ---
 
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 
 <Framed background="https://assets.mirurobotics.com/docs/v04/images/config-schemas/background.png" image="https://assets.mirurobotics.com/docs/v04/images/config-schemas/header:metadata.png" borderWidth={"24px 48px 0 0"} innerRadius={"0 8px 0 0"} />
 
 ## Create a schema  <PublisherBadge />
 
+<PlatformApiBadge endpoint="config-schemas/create" />
+
 Schemas must be created as part of a release. Visit the [define releases](/cfg-mgmt/create-a-release) page to learn how to create a release along with its schemas.
 
-**Platform API**
-
-To create a config schema programmatically, use the <PlatformApiLink endpoint="config-schemas/create">create config schema endpoint »</PlatformApiLink>
-
 ## View a schema
+
+<PlatformApiBadge endpoint="config-schemas/get" />
 
 To view a schema in Miru, navigate to the [Releases page](https://app.mirurobotics.com/releases), and click into the release that contains the schema you want to view.
 
@@ -47,9 +47,3 @@ Click into a schema to open its details, which contains the following tabs:
     </Frame>
   </Tab>
 </Tabs>
-
-**Platform API**
-
-To retrieve a config schema programmatically, use the <PlatformApiLink endpoint="config-schemas/get">get config schema endpoint »</PlatformApiLink>
-
-To list config schemas programmatically, use the <PlatformApiLink endpoint="config-schemas/list">list config schemas endpoint »</PlatformApiLink>

--- a/docs/data-uploads/primitives/buckets.mdx
+++ b/docs/data-uploads/primitives/buckets.mdx
@@ -3,6 +3,7 @@ title: "Buckets"
 ---
 
 import { ImmutableBadge, MutableBadge } from '/snippets/components/field-badges.jsx';
+import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 import BucketDef from '/snippets/definitions/bucket.mdx';
 
@@ -37,6 +38,8 @@ import BucketDef from '/snippets/definitions/bucket.mdx';
 
 ## View a bucket
 
+<DashboardOnlyBadge />
+
 To view a bucket, navigate to the [Buckets page](https://app.mirurobotics.com/settings/buckets).
 
 <Frame>
@@ -45,9 +48,13 @@ To view a bucket, navigate to the [Buckets page](https://app.mirurobotics.com/se
 
 ## Connect a bucket  <PublisherBadge />
 
+<DashboardOnlyBadge />
+
 To connect a bucket, visit the [Connect buckets](/data-uploads/primitives/buckets#connect-a-bucket) page.
 
 ## Edit a bucket  <PublisherBadge />
+
+<DashboardOnlyBadge />
 
 Editing a bucket allows you to update a bucket's authentication configuration. However, it does not allow you to change the bucket's name. To upload to a new bucket, you must create a new bucket connection.
 
@@ -65,6 +72,8 @@ Update the desired fields, then click **Save**.
 
 ## Delete a bucket  <PublisherBadge />
 
+<DashboardOnlyBadge />
+
 Deleting a bucket is only possible if there are no file rules associated with the bucket. Otherwise, you must archive the bucket instead.
 
 Navigate to the [Buckets page](https://app.mirurobotics.com/settings/buckets), click the ellipsis (…) next to the bucket you want to delete, and select **Delete**.
@@ -80,6 +89,8 @@ Click **Delete** to confirm.
 </Frame>
 
 ## Archive a bucket  <PublisherBadge />
+
+<DashboardOnlyBadge />
 
 Archiving a bucket prevents any data uploads from being written to the bucket. However, it does not delete the bucket itself, and can be unarchived at any time.
 

--- a/docs/data-uploads/primitives/buckets.mdx
+++ b/docs/data-uploads/primitives/buckets.mdx
@@ -3,7 +3,7 @@ title: "Buckets"
 ---
 
 import { ImmutableBadge, MutableBadge } from '/snippets/components/field-badges.jsx';
-import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 import BucketDef from '/snippets/definitions/bucket.mdx';
 
@@ -38,7 +38,7 @@ import BucketDef from '/snippets/definitions/bucket.mdx';
 
 ## View a bucket
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To view a bucket, navigate to the [Buckets page](https://app.mirurobotics.com/settings/buckets).
 
@@ -48,13 +48,13 @@ To view a bucket, navigate to the [Buckets page](https://app.mirurobotics.com/se
 
 ## Connect a bucket  <PublisherBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To connect a bucket, visit the [Connect buckets](/data-uploads/primitives/buckets#connect-a-bucket) page.
 
 ## Edit a bucket  <PublisherBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Editing a bucket allows you to update a bucket's authentication configuration. However, it does not allow you to change the bucket's name. To upload to a new bucket, you must create a new bucket connection.
 
@@ -72,7 +72,7 @@ Update the desired fields, then click **Save**.
 
 ## Delete a bucket  <PublisherBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Deleting a bucket is only possible if there are no file rules associated with the bucket. Otherwise, you must archive the bucket instead.
 
@@ -90,7 +90,7 @@ Click **Delete** to confirm.
 
 ## Archive a bucket  <PublisherBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Archiving a bucket prevents any data uploads from being written to the bucket. However, it does not delete the bucket itself, and can be unarchived at any time.
 

--- a/docs/data-uploads/primitives/file-rules.mdx
+++ b/docs/data-uploads/primitives/file-rules.mdx
@@ -3,7 +3,7 @@ title: "File rules"
 ---
 
 import { ImmutableBadge } from '/snippets/components/field-badges.jsx';
-import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 import FileRuleDef from '/snippets/definitions/file-rule.mdx';
 import Retention from '/snippets/file-rules/retention.mdx';
@@ -112,13 +112,13 @@ YAML that defined it.
 
 ## Create a file rule  <PublisherBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 File rules must be created as part of a [release](/primitives/releases). Visit the [define file rules](/data-uploads/define-file-rules) page to learn how to create file rules and releases.
 
 ## View a file rule
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To view a file rule in Miru, navigate to the [Releases page](https://app.mirurobotics.com/releases), and click into the release that contains the file rule you want to view.
 

--- a/docs/data-uploads/primitives/file-rules.mdx
+++ b/docs/data-uploads/primitives/file-rules.mdx
@@ -3,6 +3,7 @@ title: "File rules"
 ---
 
 import { ImmutableBadge } from '/snippets/components/field-badges.jsx';
+import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 import FileRuleDef from '/snippets/definitions/file-rule.mdx';
 import Retention from '/snippets/file-rules/retention.mdx';
@@ -111,9 +112,13 @@ YAML that defined it.
 
 ## Create a file rule  <PublisherBadge />
 
+<DashboardOnlyBadge />
+
 File rules must be created as part of a [release](/primitives/releases). Visit the [define file rules](/data-uploads/define-file-rules) page to learn how to create file rules and releases.
 
-## View a file rule 
+## View a file rule
+
+<DashboardOnlyBadge />
 
 To view a file rule in Miru, navigate to the [Releases page](https://app.mirurobotics.com/releases), and click into the release that contains the file rule you want to view.
 

--- a/docs/data-uploads/primitives/upload-collections.mdx
+++ b/docs/data-uploads/primitives/upload-collections.mdx
@@ -3,6 +3,7 @@ title: "Upload collections"
 ---
 
 import { ImmutableBadge, EditableBadge } from '/snippets/components/field-badges.jsx';
+import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 import UploadCollectionDef from '/snippets/definitions/upload-collection.mdx';
 
@@ -37,6 +38,8 @@ import UploadCollectionDef from '/snippets/definitions/upload-collection.mdx';
 </ParamField>
 
 ## Create an upload collection  <PublisherBadge />
+
+<DashboardOnlyBadge />
 
 Upload collections are created automatically when you create a file rule. Visit the [define file rules](/data-uploads/define-file-rules) page to learn how to create upload collections and file rules.
 

--- a/docs/data-uploads/primitives/upload-collections.mdx
+++ b/docs/data-uploads/primitives/upload-collections.mdx
@@ -3,7 +3,7 @@ title: "Upload collections"
 ---
 
 import { ImmutableBadge, EditableBadge } from '/snippets/components/field-badges.jsx';
-import { DashboardOnlyBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { PublisherBadge } from '/snippets/components/role-badges.jsx';
 import UploadCollectionDef from '/snippets/definitions/upload-collection.mdx';
 
@@ -39,7 +39,7 @@ import UploadCollectionDef from '/snippets/definitions/upload-collection.mdx';
 
 ## Create an upload collection  <PublisherBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Upload collections are created automatically when you create a file rule. Visit the [define file rules](/data-uploads/define-file-rules) page to learn how to create upload collections and file rules.
 

--- a/docs/primitives/devices.mdx
+++ b/docs/primitives/devices.mdx
@@ -5,7 +5,7 @@ title: "Devices"
 import { ONLINE_TOOLTIP, OFFLINE_TOOLTIP } from '/snippets/components/devices/statuses.jsx';
 import { MutableBadge, EditableBadge, NullableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { DashboardOnlyBadge, PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, ProvisionerBadge, ViewerBadge } from '/snippets/components/role-badges.jsx';
 import DeviceDef from '/snippets/definitions/device.mdx';
 import MoveDevice from '/snippets/devices/move.mdx';
@@ -116,6 +116,8 @@ To view a device's status, hover over its name on the Devices page.
 
 ## View a device
 
+<PlatformApiBadge endpoint="devices/get" />
+
 To view a device in Miru, navigate to the [Devices page](https://app.mirurobotics.com/devices), click into the device you want to view, and switch to the **Overview** tab at the top.
 
 **Metadata**
@@ -134,26 +136,13 @@ At the bottom of the page, you'll find a complete audit trail of deployments mad
   ![Device Overview Audit Trail](https://assets.mirurobotics.com/docs/v04/images/devices/overview-audit-trail.png)
 </Frame>
 
-**Platform API**
-
-To retrieve a device programmatically, use the <PlatformApiLink endpoint="devices/get">get device endpoint »</PlatformApiLink>
-
-To list devices programmatically, use the <PlatformApiLink endpoint="devices/list">list devices endpoint »</PlatformApiLink>
-
 ## Provision a device  <ProvisionerBadge />
 
-To provision a device, visit the [device provisioning](/cfg-mgmt/provision-devices/overview) .
-
-**Platform API**
-
-To create a device programmatically, use the <PlatformApiLink endpoint="devices/create">create device endpoint »</PlatformApiLink>
-
-To provision devices programmatically, use [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens), which are created with the <PlatformApiLink endpoint="provisioning-tokens/create">create provisioning token endpoint »</PlatformApiLink>
-
+To provision a device, visit the [device provisioning](/cfg-mgmt/provision-devices/overview) documentation.
 
 ## Edit a device  <ProvisionerBadge />
 
-**Dashboard**
+<PlatformApiBadge endpoint="devices/update" />
 
 Navigate to the [Devices page](https://app.mirurobotics.com/devices), click the ellipses (...) on the device you want to edit, and hit **Edit**.
 
@@ -167,11 +156,9 @@ Update the desired fields, then click **Save**.
   ![Edit Device Dialog](https://assets.mirurobotics.com/docs/v04/images/devices/edit-dialog.png)
 </Frame>
 
-**Platform API**
-
-To edit a device programmatically, use the <PlatformApiLink endpoint="devices/update">update device endpoint »</PlatformApiLink>
-
 ## Ping a device  <ViewerBadge />
+
+<PlatformApiBadge endpoint="devices/ping" />
 
 Pinging a device sends a real-time request to verify whether it is online. Ping requests wait up to 5 seconds for a response from the device before timing out.
 
@@ -187,19 +174,17 @@ On the other hand, <Tooltip tip={OFFLINE_TOOLTIP.tip} cta={OFFLINE_TOOLTIP.cta} 
   ![Ping Timeout](https://assets.mirurobotics.com/docs/v04/images/devices/ping-timeout.png)
 </Frame>
 
-**Platform API**
-
-To ping a device programmatically, use the <PlatformApiLink endpoint="devices/ping">ping device endpoint »</PlatformApiLink>
-
 ## Move a device  <AdminBadge />
+
+<DashboardOnlyBadge />
 
 <MoveDevice />
 
 ## Delete a device  <ProvisionerBadge />
 
-Deleting a device immediately invalidates its authentication session and removes all deployment and configuration history. This action is irreversible. Please proceed with caution.
+<DashboardOnlyBadge />
 
-**Dashboard**
+Deleting a device immediately invalidates its authentication session and removes all deployment and configuration history. This action is irreversible. Please proceed with caution.
 
 To delete a device, click the ellipses (...) on the device you want to delete and hit **Delete**.
 

--- a/docs/primitives/devices.mdx
+++ b/docs/primitives/devices.mdx
@@ -5,7 +5,7 @@ title: "Devices"
 import { ONLINE_TOOLTIP, OFFLINE_TOOLTIP } from '/snippets/components/devices/statuses.jsx';
 import { MutableBadge, EditableBadge, NullableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { DashboardOnlyBadge, PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge, PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, ProvisionerBadge, ViewerBadge } from '/snippets/components/role-badges.jsx';
 import DeviceDef from '/snippets/definitions/device.mdx';
 import MoveDevice from '/snippets/devices/move.mdx';
@@ -176,13 +176,13 @@ On the other hand, <Tooltip tip={OFFLINE_TOOLTIP.tip} cta={OFFLINE_TOOLTIP.cta} 
 
 ## Move a device  <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 <MoveDevice />
 
 ## Delete a device  <ProvisionerBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Deleting a device immediately invalidates its authentication session and removes all deployment and configuration history. This action is irreversible. Please proceed with caution.
 

--- a/docs/primitives/groups.mdx
+++ b/docs/primitives/groups.mdx
@@ -4,7 +4,7 @@ title: "Groups"
 
 import { EditableBadge, MutableBadge, NullableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { DashboardOnlyBadge, PlatformApiBadge, PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge, PlatformApiLink, PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, GroupManagerBadge } from '/snippets/components/role-badges.jsx';
 import MoveDevice from '/snippets/devices/move.mdx';
 
@@ -117,13 +117,13 @@ To move a group to a new parent group—or to the top level by setting `parent_i
 
 ## Move a device  <AdminBadge />  <GroupManagerBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 <MoveDevice />
 
 ## Delete a group  <AdminBadge />  <GroupManagerBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 A group can only be deleted if it has no subgroups and no assigned devices. If you need to delete a group that still contains devices or subgroups, first move or reassign its contents.
 
@@ -141,7 +141,7 @@ A confirmation dialog will appear. Hit **Delete** to confirm the deletion.
 
 ## Add a member  <AdminBadge />  <GroupManagerBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To add a member to a group, navigate to the [Groups page](https://app.mirurobotics.com/groups), click the ellipses (...) on the group you want to add a member to, and select **Members** from the dropdown. 
 
@@ -163,7 +163,7 @@ To add a member, input the name of the member you want to add in the search bar 
 
 ## Edit a member's access  <AdminBadge />  <GroupManagerBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To edit a member's access to a group, navigate to the [Groups page](https://app.mirurobotics.com/groups), click the ellipses (...) on the group you want to edit, and select **Members** from the dropdown. 
 
@@ -191,7 +191,7 @@ A panel will appear with the member's workspace roles and all of their group rol
 
 ## Remove a member  <AdminBadge />  <GroupManagerBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 To remove a member from a group, navigate to the [Groups page](https://app.mirurobotics.com/groups), click the ellipses (...) on the group you want to remove a member from, and select **Members** from the dropdown. 
 

--- a/docs/primitives/groups.mdx
+++ b/docs/primitives/groups.mdx
@@ -4,7 +4,7 @@ title: "Groups"
 
 import { EditableBadge, MutableBadge, NullableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { DashboardOnlyBadge, PlatformApiBadge, PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, GroupManagerBadge } from '/snippets/components/role-badges.jsx';
 import MoveDevice from '/snippets/devices/move.mdx';
 
@@ -73,19 +73,13 @@ Devices belong to at most one group. Devices that haven't been assigned to any g
 
 ## View a group
 
-**Dashboard**
+<PlatformApiBadge endpoint="groups/get" />
 
 To view your workspace's groups, navigate to the [Groups page](https://app.mirurobotics.com/groups).
 
-**Platform API**
-
-To retrieve a group programmatically, use the <PlatformApiLink endpoint="groups/get">get group endpoint »</PlatformApiLink>
-
-To list groups programmatically, use the <PlatformApiLink endpoint="groups/list">list groups endpoint »</PlatformApiLink>
-
 ## Create a group  <AdminBadge />  <GroupManagerBadge />
 
-**Dashboard**
+<PlatformApiBadge endpoint="groups/create" />
 
 Go to the [Groups page](https://app.mirurobotics.com/groups) and navigate into the group you want to create a group inside of. Click the **+ Group** button in the top right corner.
 
@@ -99,13 +93,9 @@ Fill in the fields, then click **Create**.
   ![Create Group Dialog](https://assets.mirurobotics.com/docs/v04/images/groups/create-dialog.png)
 </Frame>
 
-**Platform API**
-
-To create a group programmatically, use the <PlatformApiLink endpoint="groups/create">create group endpoint »</PlatformApiLink>
-
 ## Edit a group  <AdminBadge />  <GroupManagerBadge />
 
-**Dashboard**
+<PlatformApiBadge endpoint="groups/update" />
 
 Navigate to the [Groups page](https://assets.mirurobotics.com/docs/v04/images/groups/page.png), click the ellipses (...) on the group you want to edit, and hit **Edit**.
 
@@ -119,21 +109,21 @@ Update the desired fields, then click **Save**.
   ![Edit Group Dialog](https://assets.mirurobotics.com/docs/v04/images/groups/edit-dialog.png)
 </Frame>
 
-**Platform API**
-
-To edit a group programmatically, use the <PlatformApiLink endpoint="groups/update">update group endpoint »</PlatformApiLink>
-
 ## Move a group  <AdminBadge />  <GroupManagerBadge />
 
-**Platform API**
+<PlatformApiBadge endpoint="groups/move" />
 
 To move a group to a new parent group—or to the top level by setting `parent_id` to `null`—use the <PlatformApiLink endpoint="groups/move">move group endpoint »</PlatformApiLink>
 
 ## Move a device  <AdminBadge />  <GroupManagerBadge />
 
+<DashboardOnlyBadge />
+
 <MoveDevice />
 
 ## Delete a group  <AdminBadge />  <GroupManagerBadge />
+
+<DashboardOnlyBadge />
 
 A group can only be deleted if it has no subgroups and no assigned devices. If you need to delete a group that still contains devices or subgroups, first move or reassign its contents.
 
@@ -150,6 +140,8 @@ A confirmation dialog will appear. Hit **Delete** to confirm the deletion.
 </Frame>
 
 ## Add a member  <AdminBadge />  <GroupManagerBadge />
+
+<DashboardOnlyBadge />
 
 To add a member to a group, navigate to the [Groups page](https://app.mirurobotics.com/groups), click the ellipses (...) on the group you want to add a member to, and select **Members** from the dropdown. 
 
@@ -170,6 +162,8 @@ To add a member, input the name of the member you want to add in the search bar 
 </Frame>
 
 ## Edit a member's access  <AdminBadge />  <GroupManagerBadge />
+
+<DashboardOnlyBadge />
 
 To edit a member's access to a group, navigate to the [Groups page](https://app.mirurobotics.com/groups), click the ellipses (...) on the group you want to edit, and select **Members** from the dropdown. 
 
@@ -196,6 +190,8 @@ A panel will appear with the member's workspace roles and all of their group rol
 </Frame>
 
 ## Remove a member  <AdminBadge />  <GroupManagerBadge />
+
+<DashboardOnlyBadge />
 
 To remove a member from a group, navigate to the [Groups page](https://app.mirurobotics.com/groups), click the ellipses (...) on the group you want to remove a member from, and select **Members** from the dropdown. 
 

--- a/docs/primitives/releases.mdx
+++ b/docs/primitives/releases.mdx
@@ -4,7 +4,7 @@ title: "Releases"
 
 import { ImmutableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { DashboardOnlyBadge, PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
+import { PlatformApiBadge, PlatformUnsupportedBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, PublisherBadge } from '/snippets/components/role-badges.jsx';
 import ReleaseDef from '/snippets/definitions/release.mdx';
 import SemVer from '/snippets/releases/semver.mdx';
@@ -78,7 +78,7 @@ A dialog will appear—input the new version name and hit **Create**.
 
 ## Delete a release  <AdminBadge />
 
-<DashboardOnlyBadge />
+<PlatformUnsupportedBadge />
 
 Deleting a release is only possible if no deployments have been delivered to any device with that release. Otherwise, the release cannot be deleted.
 

--- a/docs/primitives/releases.mdx
+++ b/docs/primitives/releases.mdx
@@ -56,7 +56,7 @@ If you want to add [file rules](/data-uploads/primitives/file-rules) to your rel
 
 ## Duplicate a release  <PublisherBadge />
 
-<PlatformApiBadge endpoint="releases/create" tip="Use the create release endpoint to duplicate a release." />
+<PlatformApiBadge endpoint="releases/create" />
 
 Duplicating a release creates a new release with the same config schemas and git information as the original. 
 

--- a/docs/primitives/releases.mdx
+++ b/docs/primitives/releases.mdx
@@ -4,7 +4,7 @@ title: "Releases"
 
 import { ImmutableBadge } from '/snippets/components/field-badges.jsx';
 import { Framed } from '/snippets/components/framed.jsx';
-import { PlatformApiLink } from '/snippets/components/platform-api-link.jsx';
+import { DashboardOnlyBadge, PlatformApiBadge } from '/snippets/components/platform-api-link.jsx';
 import { AdminBadge, PublisherBadge } from '/snippets/components/role-badges.jsx';
 import ReleaseDef from '/snippets/definitions/release.mdx';
 import SemVer from '/snippets/releases/semver.mdx';
@@ -40,7 +40,7 @@ import SemVer from '/snippets/releases/semver.mdx';
 
 ## View a release
 
-**Dashboard**
+<PlatformApiBadge endpoint="releases/get" />
 
 To view a release and its schemas, click into the release from the releases page and switch to the **Overview** tab at the top.
 
@@ -48,23 +48,15 @@ To view a release and its schemas, click into the release from the releases page
   ![Release Overview](https://assets.mirurobotics.com/docs/v04/images/releases/overview.png)
 </Frame>
 
-**Platform API**
-
-To retrieve a release programmatically, use the <PlatformApiLink endpoint="releases/get">get release endpoint »</PlatformApiLink>
-
-To list releases programmatically, use the <PlatformApiLink endpoint="releases/list">list releases endpoint »</PlatformApiLink>
-
 ## Create a release  <PublisherBadge />
 
-To create a release, visit the config management [create a release](/cfg-mgmt/create-a-release) guide. 
+<PlatformApiBadge endpoint="releases/create" />
 
 If you want to add [file rules](/data-uploads/primitives/file-rules) to your release, visit the data uploads [define file rules](/data-uploads/define-file-rules) guide.
 
-**Platform API**
-
-To create a release programmatically, use the <PlatformApiLink endpoint="releases/create">create release endpoint »</PlatformApiLink>
-
 ## Duplicate a release  <PublisherBadge />
+
+<PlatformApiBadge endpoint="releases/create" tip="Use the create release endpoint to duplicate a release." />
 
 Duplicating a release creates a new release with the same config schemas and git information as the original. 
 
@@ -85,6 +77,8 @@ A dialog will appear—input the new version name and hit **Create**.
 </Frame>
 
 ## Delete a release  <AdminBadge />
+
+<DashboardOnlyBadge />
 
 Deleting a release is only possible if no deployments have been delivered to any device with that release. Otherwise, the release cannot be deleted.
 

--- a/docs/primitives/releases.mdx
+++ b/docs/primitives/releases.mdx
@@ -52,7 +52,7 @@ To view a release and its schemas, click into the release from the releases page
 
 <PlatformApiBadge endpoint="releases/create" />
 
-If you want to add [file rules](/data-uploads/primitives/file-rules) to your release, visit the data uploads [define file rules](/data-uploads/define-file-rules) guide.
+Releases are created via the CLI — visit the config management [create a release](/cfg-mgmt/create-a-release) guide. To add [file rules](/data-uploads/primitives/file-rules) to a release, visit the data uploads [define file rules](/data-uploads/define-file-rules) guide.
 
 ## Duplicate a release  <PublisherBadge />
 

--- a/docs/snippets/components/platform-api-link.jsx
+++ b/docs/snippets/components/platform-api-link.jsx
@@ -1,3 +1,9 @@
+/*
+ * Mintlify only evaluates the exported bindings in a snippet file, so module-level
+ * helpers and constants are not in scope at render time. Each component below must
+ * build its own href — when the latest API version changes, bump it in each.
+ */
+
 /**
  * Link to a Platform API endpoint using the latest API version.
  *
@@ -11,4 +17,66 @@ export const PlatformApiLink = ({ endpoint, newTab, children }) => {
     return <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>;
   }
   return <a href={href}>{children}</a>;
+};
+
+/**
+ * Clickable badge marking an operation as available in the Platform API.
+ * Place on its own line directly beneath the section heading. Opens the endpoint
+ * reference in a new tab so the reader keeps their place in the dashboard steps.
+ *
+ * Where a section covers several endpoints, link the primary one and keep the
+ * generic label. Override `tip` when the endpoint doesn't map one-to-one to the
+ * operation (e.g. "Use the create release endpoint to duplicate a release.").
+ *
+ * Mintlify tags bare MDX anchors with `class="link"`, which underlines them with
+ * a border-bottom rather than text-decoration — both have to be cleared here.
+ *
+ * @param {string} endpoint - Path after /endpoints/, e.g. "groups/create"
+ * @param {string} [label] - Badge text
+ * @param {string} [tip] - Hover explanation; defaults to a generic one
+ */
+export const PlatformApiBadge = ({ endpoint, label = "Platform API", tip }) => {
+  const href = `/references/platform-api/2026-08-17/endpoints/${endpoint}`;
+  return (
+    <Tooltip tip={tip ?? "Open the Platform API reference for this operation"}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ textDecoration: 'none', borderBottom: 'none' }}
+      >
+        <span
+          className="inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-sm text-[rgb(var(--gray-500))] dark:text-[rgb(var(--gray-400))] hover:bg-[rgb(var(--gray-100))] dark:hover:bg-[rgb(var(--gray-800))] hover:text-[rgb(var(--gray-700))] dark:hover:text-[rgb(var(--gray-200))]"
+          style={{ marginLeft: '-0.5rem' }}
+        >
+          {label} <Icon icon="arrow-up-right" size={13} color="currentColor" />
+        </span>
+      </a>
+    </Tooltip>
+  );
+};
+
+/**
+ * Inert counterpart to PlatformApiBadge for operations with no Platform API
+ * endpoint. Same ghost styling and placement, but no link, arrow, or hover
+ * background — it must not read as clickable. The slash icon plus hover tip
+ * carry the "not supported" signal.
+ *
+ * When an endpoint ships for a marked operation, replace this with a
+ * PlatformApiBadge — grep the docs for DashboardOnlyBadge when new endpoints
+ * are released.
+ *
+ * @param {string} [tip] - Hover explanation; defaults to a generic one
+ */
+export const DashboardOnlyBadge = ({ tip }) => {
+  return (
+    <Tooltip tip={tip ?? "Platform API does not support this operation"}>
+      <span
+        className="inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-sm text-[rgb(var(--gray-500))] dark:text-[rgb(var(--gray-400))]"
+        style={{ marginLeft: '-0.5rem', cursor: 'default' }}
+      >
+        <Icon icon="ban" size={13} color="currentColor" /> Platform API
+      </span>
+    </Tooltip>
+  );
 };

--- a/docs/snippets/components/platform-api-link.jsx
+++ b/docs/snippets/components/platform-api-link.jsx
@@ -25,20 +25,18 @@ export const PlatformApiLink = ({ endpoint, newTab, children }) => {
  * reference in a new tab so the reader keeps their place in the dashboard steps.
  *
  * Where a section covers several endpoints, link the primary one and keep the
- * generic label. Override `tip` when the endpoint doesn't map one-to-one to the
- * operation (e.g. "Use the create release endpoint to duplicate a release.").
+ * generic label.
  *
  * Mintlify tags bare MDX anchors with `class="link"`, which underlines them with
  * a border-bottom rather than text-decoration — both have to be cleared here.
  *
  * @param {string} endpoint - Path after /endpoints/, e.g. "groups/create"
  * @param {string} [label] - Badge text
- * @param {string} [tip] - Hover explanation; defaults to a generic one
  */
-export const PlatformApiBadge = ({ endpoint, label = "Platform API", tip }) => {
+export const PlatformApiBadge = ({ endpoint, label = "Platform API" }) => {
   const href = `/references/platform-api/2026-08-17/endpoints/${endpoint}`;
   return (
-    <Tooltip tip={tip ?? "Open the Platform API reference for this operation"}>
+    <Tooltip tip="Open the Platform API reference for this operation">
       <a
         href={href}
         target="_blank"
@@ -65,12 +63,10 @@ export const PlatformApiBadge = ({ endpoint, label = "Platform API", tip }) => {
  * When an endpoint ships for a marked operation, replace this with a
  * PlatformApiBadge — grep the docs for DashboardOnlyBadge when new endpoints
  * are released.
- *
- * @param {string} [tip] - Hover explanation; defaults to a generic one
  */
-export const DashboardOnlyBadge = ({ tip }) => {
+export const DashboardOnlyBadge = () => {
   return (
-    <Tooltip tip={tip ?? "Platform API does not support this operation"}>
+    <Tooltip tip="Platform API does not support this operation">
       <span
         className="inline-flex items-center gap-1.5 rounded-lg px-2 py-0.5 text-sm text-[rgb(var(--gray-500))] dark:text-[rgb(var(--gray-400))]"
         style={{ marginLeft: '-0.5rem', cursor: 'default' }}

--- a/docs/snippets/components/platform-api-link.jsx
+++ b/docs/snippets/components/platform-api-link.jsx
@@ -61,10 +61,10 @@ export const PlatformApiBadge = ({ endpoint, label = "Platform API" }) => {
  * carry the "not supported" signal.
  *
  * When an endpoint ships for a marked operation, replace this with a
- * PlatformApiBadge — grep the docs for DashboardOnlyBadge when new endpoints
+ * PlatformApiBadge — grep the docs for PlatformUnsupportedBadge when new endpoints
  * are released.
  */
-export const DashboardOnlyBadge = () => {
+export const PlatformUnsupportedBadge = () => {
   return (
     <Tooltip tip="Platform API does not support this operation">
       <span


### PR DESCRIPTION
## Summary
- Add `PlatformApiBadge` (ghost link badge that opens an operation's endpoint reference in a new tab) and `PlatformUnsupportedBadge` (inert slash-icon counterpart), both self-explaining on hover, themed from the site's gray variables.
- Replace the bold **Dashboard** / **Platform API** prose lead-ins on operation sections with a single badge beneath each heading; pointer-only endpoint sentences are removed while instructive prose (staging `target_status`, patch `parent_id`, drift review, content download) is kept.
- Mark every operation with no endpoint in the 2026-08-17 spec — buckets, file rules, upload collections, API keys, member management, and dashboard-only primitives operations — with the unsupported badge so absence of an API path is explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789616855&installation_model_id=425273&pr_number=164&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F164&signature=85bcd85be62899947170c5888a6e7e3faeca0eec4db0f0a1ed78074c147c9933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->