### PR TITLE
docs: update miru version output for cli identity and build info

### DIFF
--- a/docs/developers/cli/install.mdx
+++ b/docs/developers/cli/install.mdx
@@ -15,9 +15,12 @@ To verify the CLI is installed and up to date, run the `miru version` command.
 
 ```bash
 $ miru version
+Miru CLI
 Version: 0.10.0
 Commit: 76b320c4ecec7a8e4b12cabb635831a4ad1d5d28
 Built: 2026-04-20T02:54:55Z
+Go: go1.26.0
+OS/Arch: darwin/arm64
 ```
 
 You can find the CLI release changelog in the [CLI changelog](/changelog/cli).

--- a/docs/references/cli/version.mdx
+++ b/docs/references/cli/version.mdx
@@ -4,7 +4,7 @@ title: "Version"
 
 Print the version information of the installed CLI.
 
-`version` runs entirely offline — it takes no flags and requires no authentication. The first output line identifies the binary as the Miru CLI, distinguishing it from the [Miru agent](/developers/agent/overview) that runs on devices.
+`version` runs entirely offline — it takes no flags and requires no authentication.
 
 ### Usage
 

--- a/docs/references/cli/version.mdx
+++ b/docs/references/cli/version.mdx
@@ -4,7 +4,7 @@ title: "Version"
 
 Print the version information of the installed CLI.
 
-`version` runs entirely offline — it takes no flags and requires no authentication.
+`version` runs entirely offline — it takes no flags and requires no authentication. The first output line identifies the binary as the Miru CLI, distinguishing it from the [Miru agent](/developers/agent/overview) that runs on devices.
 
 ### Usage
 
@@ -14,9 +14,14 @@ miru version
 
 ```
 $ miru version
+Miru CLI
 Version: 0.11.0
 Commit: 3f9c1d27b45e80aa612f9dc0be174c58a2e6f4b1
 Built: 2026-08-12T18:24:09Z
+Go: go1.26.0
+OS/Arch: darwin/arm64
 ```
+
+`Version`, `Commit`, and `Built` are stamped at release time. `Go` and `OS/Arch` report the Go toolchain and the platform the binary was built for.
 
 To upgrade an out-of-date CLI, follow the [upgrade steps](/developers/cli/install#upgrade). Release history lives in the [CLI changelog](/changelog/cli).


### PR DESCRIPTION
## Summary
- Updates the CLI reference page (`docs/references/cli/version.mdx`) for the new `miru version` output shipped in mirurobotics/cli-private#147: the sample transcript now opens with the `Miru CLI` identity line and includes the new `Go:` and `OS/Arch:` lines, with a sentence explaining the identity line distinguishes the CLI from the [Miru agent](/developers/agent/overview) and a note on which fields are stamped at release time vs derived from the toolchain.
- Updates the stale sample output in the install guide's Verify section (`docs/developers/cli/install.mdx`) to match.

## Context
The reference page was added in #165 against the CLI's previous three-line output; cli-private#147 (merged immediately after) changed the output to six lines.

## Validation
- `./scripts/lint.sh` — "All documentation lint checks passed."

---
_Generated by [Claude Code](https://claude.ai/code/session_01GL3E9bjchNWXbk6i78m7i5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789685764&installation_model_id=425273&pr_number=166&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F166&signature=e5ebd30bc1b6d2efcc86be20349fd65e1a4aebb2a924602d1ff0c05562c5fd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->