### PR TITLE
docs(changelog): add CLI v0.11.1 release notes

### DIFF
--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -7,6 +7,45 @@ description: "Changelog and migration steps for the Miru CLI"
 import { Dropdown } from '/snippets/components/api-dropdown.jsx';
 
 
+# v0.11.1
+
+*August 27, 2026*
+
+CLI `v0.11.1` adds commands for cloning and staging device configs, validating a schema without creating a release, and showing the authenticated principal. Interactive login now uses the OAuth device authorization flow instead of pasting a dashboard token.
+
+## Breaking changes
+
+<Dropdown title="Interactive login">
+
+`miru login` no longer prompts you to paste a token from the dashboard. It opens a verification URL in your browser and waits until you approve access. On SSH sessions or headless machines, pass `--no-browser` to print the URL instead of opening it.
+
+Stored tokens from earlier logins and `MIRU_API_KEY` authentication are unchanged.
+
+</Dropdown>
+
+## Features
+
+- Add [`miru device clone`](/references/cli/device-clone) to write a device's current deployment configs onto disk
+- Add [`miru device stage`](/references/cli/device-stage) to stage a deployment from local config files
+- Add [`miru deployment clone`](/references/cli/deployment-clone) to write a specific deployment's configs onto disk
+- Add [`miru schema validate`](/references/cli/schema-validate) to check a schema against the same server rules as `miru release create` without creating anything
+- Add [`miru whoami`](/references/cli/whoami) to show the authenticated principal and workspace
+- Add the `MIRU_HOME` environment variable to override the CLI state directory (defaults to `~/.miru`)
+
+## Improvements
+
+- `miru version` now prints a `Miru CLI` header plus `Go` and `OS/Arch` lines
+- Clone and stage transcripts render config files as a single tree
+- Refuse to create CLI state under a directory this user does not own, and report the resolved credentials path
+
+## Fixes
+
+- Fix a race where `miru login` could miss a browser approval before the first poll
+- Show API key scopes on `miru whoami`
+- Report a permission-denied or read-only clone destination as such, and an unreachable stage slot file as unreachable rather than missing
+
+---
+
 # v0.11.0
 
 *August 12, 2026*

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -36,7 +36,7 @@ Stored tokens from earlier logins and `MIRU_API_KEY` authentication are unchange
 
 - `miru version` now prints a `Miru CLI` header plus `Go` and `OS/Arch` lines
 - Clone and stage transcripts render config files as a single tree
-- Refuse to create CLI state under a directory this user does not own, and report the resolved credentials path
+- Refuse to create CLI state under a directory this user does not own
 
 ## Fixes
 

--- a/docs/changelog/cli.mdx
+++ b/docs/changelog/cli.mdx
@@ -7,11 +7,11 @@ description: "Changelog and migration steps for the Miru CLI"
 import { Dropdown } from '/snippets/components/api-dropdown.jsx';
 
 
-# v0.11.1
+# v0.12.0
 
 *August 27, 2026*
 
-CLI `v0.11.1` adds commands for cloning and staging device configs, validating a schema without creating a release, and showing the authenticated principal. Interactive login now uses the OAuth device authorization flow instead of pasting a dashboard token.
+CLI `v0.12.0` adds commands for cloning and staging device configs, validating a schema without creating a release, and showing the authenticated principal. Interactive login now uses the OAuth device authorization flow instead of pasting a dashboard token. The previous login flow is no longer supported, so local login requires `v0.12.0` or later.
 
 ## Breaking changes
 
@@ -23,26 +23,25 @@ Stored tokens from earlier logins and `MIRU_API_KEY` authentication are unchange
 
 </Dropdown>
 
+<Danger>
+The previous paste-token login flow is no longer supported. CLI versions before `v0.12.0` do not support `miru login`. Upgrade to `v0.12.0` or later to log in to the CLI on your development machine.
+</Danger>
+
+CI pipelines that authenticate with `MIRU_API_KEY` continue to work with earlier CLI versions.
+
 ## Features
 
-- Add [`miru device clone`](/references/cli/device-clone) to write a device's current deployment configs onto disk
-- Add [`miru device stage`](/references/cli/device-stage) to stage a deployment from local config files
-- Add [`miru deployment clone`](/references/cli/deployment-clone) to write a specific deployment's configs onto disk
-- Add [`miru schema validate`](/references/cli/schema-validate) to check a schema against the same server rules as `miru release create` without creating anything
+- Add [`miru device clone`](/references/cli/device-clone) to write the config files of a device's current deployment onto your local machine's disk
+- Add [`miru device stage`](/references/cli/device-stage) to stage a deployment from your local machine's disk
+- Add [`miru deployment clone`](/references/cli/deployment-clone) to write the config files of any deployment onto your local machine's disk
+- Add [`miru schema validate`](/references/cli/schema-validate) to check a schema against the same server rules as `miru release create` without creating any resources
 - Add [`miru whoami`](/references/cli/whoami) to show the authenticated principal and workspace
 - Add the `MIRU_HOME` environment variable to override the CLI state directory (defaults to `~/.miru`)
 
 ## Improvements
 
 - `miru version` now prints a `Miru CLI` header plus `Go` and `OS/Arch` lines
-- Clone and stage transcripts render config files as a single tree
-- Refuse to create CLI state under a directory this user does not own
-
-## Fixes
-
-- Fix a race where `miru login` could miss a browser approval before the first poll
-- Show API key scopes on `miru whoami`
-- Report a permission-denied or read-only clone destination as such, and an unreachable stage slot file as unreachable rather than missing
+- Refuse to create CLI state under a directory the CLI user does not own
 
 ---
 

--- a/plans/active/20260827-cli-v0.11.1-changelog.md
+++ b/plans/active/20260827-cli-v0.11.1-changelog.md
@@ -23,7 +23,7 @@ The public CLI changelog at `/changelog/cli` still opens with `# v0.11.0` (*Augu
 - [x] Milestone 1: Re-verify the latest shipped CLI version and the user-facing delta.
 - [x] Milestone 2: Insert the `# v0.11.1` section into `docs/changelog/cli.mdx` and commit.
 - [x] Milestone 3: Run the docs test/lint commands; fix any findings; commit if needed.
-- [ ] Milestone 4: Push, open a draft PR, and drive preflight to `CLEAN` (CI green on the pushed head).
+- [x] Milestone 4: Push, open a draft PR, and drive preflight to `CLEAN` (CI green on the pushed head).
 
 ## Surprises & Discoveries
 
@@ -48,6 +48,7 @@ The public CLI changelog at `/changelog/cli` still opens with `# v0.11.0` (*Augu
 - Milestone 2: `# v0.11.1` inserted after the import; `v0.11.0` untouched. Commit `715f14d` (`docs(changelog): add CLI v0.11.1 release notes`).
 - Step 2 refine: 39-line single-file changelog (plan excluded) exceeded the <30-line fast path. Review: no findings. No refine commit.
 - Milestone 3 / tests: adjusted test plan is no new files. `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` all exited 0. CSpell 0 issues. No `cspell.json` change.
+- Milestone 4: Draft PR https://github.com/mirurobotics/docs/pull/171. First CI head `58bcaca` — lint, audit, changes, shell-tests passed (Mintlify Deployment / [code]smith skipped). Preflight `CLEAN`.
 
 ## Context and Orientation
 

--- a/plans/active/20260827-cli-v0.11.1-changelog.md
+++ b/plans/active/20260827-cli-v0.11.1-changelog.md
@@ -20,29 +20,29 @@ The public CLI changelog at `/changelog/cli` still opens with `# v0.11.0` (*Augu
 
 ## Progress
 
-- [ ] Milestone 1: Re-verify the latest shipped CLI version and the user-facing delta.
-- [ ] Milestone 2: Insert the `# v0.11.1` section into `docs/changelog/cli.mdx` and commit.
-- [ ] Milestone 3: Run the docs test/lint commands; fix any findings; commit if needed.
+- [x] Milestone 1: Re-verify the latest shipped CLI version and the user-facing delta.
+- [x] Milestone 2: Insert the `# v0.11.1` section into `docs/changelog/cli.mdx` and commit.
+- [x] Milestone 3: Run the docs test/lint commands; fix any findings; commit if needed.
 - [ ] Milestone 4: Push, open a draft PR, and drive preflight to `CLEAN` (CI green on the pushed head).
 
 ## Surprises & Discoveries
 
-(Add entries as work proceeds.)
-
-- Observation: …
-  Evidence: …
+- Observation: No stable `v0.11.1` tag exists; newest tag is still `v0.11.1-beta.10` (`publishedAt` `2026-08-27T23:41:24Z`). `v0.11.0` remains Latest.
+  Evidence: `gh release list -R mirurobotics/cli --limit 15`; `gh release view v0.11.1` returned `release not found`.
+- Observation: No new user-facing command landed after this plan. Intra-beta `miru deployment stage` and `--device` remain unpublished in a stable release.
+  Evidence: `git -C cli-private log v0.11.0..origin/main --oneline --no-merges` plus `v0.11.1-beta.10` notes. Public command is still `miru device stage`.
 
 ## Decision Log
 
-(Add entries as you go.)
-
-- Decision: …
-  Rationale: …
-  Date/Author: …
+- Decision: Keep heading `# v0.11.1` and date *August 27, 2026*; use the Plan of Work entry unchanged.
+  Rationale: Milestone 1 matches the plan's fallback (newest `v0.11.1*` UTC day; no stable tag). Features / Breaking / Fixes still map to the listed commits.
+  Date/Author: 2026-08-27 / implementer
 
 ## Outcomes & Retrospective
 
-(Summarize at completion or major milestones.)
+- Milestone 2: `# v0.11.1` inserted after the import; `v0.11.0` untouched. Commit `715f14d` (`docs(changelog): add CLI v0.11.1 release notes`).
+- Step 2 refine: 39-line single-file changelog (plan excluded) exceeded the <30-line fast path. Review: no findings. No refine commit.
+- Milestone 3 / tests: adjusted test plan is no new files. `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` all exited 0. CSpell 0 issues. No `cspell.json` change.
 
 ## Context and Orientation
 

--- a/plans/active/20260827-cli-v0.11.1-changelog.md
+++ b/plans/active/20260827-cli-v0.11.1-changelog.md
@@ -31,11 +31,16 @@ The public CLI changelog at `/changelog/cli` still opens with `# v0.11.0` (*Augu
   Evidence: `gh release list -R mirurobotics/cli --limit 15`; `gh release view v0.11.1` returned `release not found`.
 - Observation: No new user-facing command landed after this plan. Intra-beta `miru deployment stage` and `--device` remain unpublished in a stable release.
   Evidence: `git -C cli-private log v0.11.0..origin/main --oneline --no-merges` plus `v0.11.1-beta.10` notes. Public command is still `miru device stage`.
+- Observation: `fix(cli): report the resolved creds path` (#175) never shipped a path on Auth Source. The merge deleted the hardcoded `~/.miru/creds.json` label.
+  Evidence: Preflight refine vs `cli-private` `identity.go` and current whoami/login docs snippets.
 
 ## Decision Log
 
-- Decision: Keep heading `# v0.11.1` and date *August 27, 2026*; use the Plan of Work entry unchanged.
+- Decision: Keep heading `# v0.11.1` and date *August 27, 2026*; use the Plan of Work entry unchanged at insert time.
   Rationale: Milestone 1 matches the plan's fallback (newest `v0.11.1*` UTC day; no stable tag). Features / Breaking / Fixes still map to the listed commits.
+  Date/Author: 2026-08-27 / implementer
+- Decision: Drop `, and report the resolved credentials path` from the ownership Improvements bullet.
+  Rationale: Preflight refine found that #175 never shipped a resolved creds path on `origin/main`; `miru whoami` and login print a pathless Auth Source. Keep only the unowned-state-directory refusal (#171).
   Date/Author: 2026-08-27 / implementer
 
 ## Outcomes & Retrospective
@@ -120,7 +125,7 @@ Use this entry unless Milestone 1 contradicts it. Indentation in the file is col
 
     - `miru version` now prints a `Miru CLI` header plus `Go` and `OS/Arch` lines
     - Clone and stage transcripts render config files as a single tree
-    - Refuse to create CLI state under a directory this user does not own, and report the resolved credentials path
+    - Refuse to create CLI state under a directory this user does not own
 
     ## Fixes
 

--- a/plans/active/20260827-cli-v0.11.1-changelog.md
+++ b/plans/active/20260827-cli-v0.11.1-changelog.md
@@ -1,0 +1,242 @@
+# Add the CLI v0.11.1 changelog entry
+
+This ExecPlan is a living document. The sections Progress, Surprises & Discoveries, Decision Log, and Outcomes & Retrospective must be kept up to date as work proceeds.
+
+## Scope
+
+| Repository | Access | Description |
+|-----------|--------|-------------|
+| `docs/` (`/home/ben/miru/workbench1/repos/docs`) | read-write | Insert one new version section at the top of `docs/changelog/cli.mdx`. Touch `cspell.json` only if CSpell flags a new word. |
+| `cli-private/` (`/home/ben/miru/workbench1/repos/cli-private`) | read-only | Implementation history since `v0.11.0`. Do not modify. |
+| `mirurobotics/cli` on GitHub | read-only | Public release tags and notes. There is no local `cli/` checkout. |
+
+This plan lives in `docs/plans/` because the only write is the public CLI changelog in this repo.
+
+Working branch: `docs/cli-latest-changelog` (already created from latest `main`). Do not create another branch. Base branch for the PR: `main`.
+
+## Purpose / Big Picture
+
+The public CLI changelog at `/changelog/cli` still opens with `# v0.11.0` (*August 12, 2026*). The install and version pages already show `Version: 0.11.1`, and the CLI Reference already documents the new commands. After this change, `/changelog/cli` opens with a `# v0.11.1` section that lists only user-facing changes shipped after `v0.11.0`, using this file's existing categories: Breaking changes, Features, Improvements, Fixes.
+
+## Progress
+
+- [ ] Milestone 1: Re-verify the latest shipped CLI version and the user-facing delta.
+- [ ] Milestone 2: Insert the `# v0.11.1` section into `docs/changelog/cli.mdx` and commit.
+- [ ] Milestone 3: Run the docs test/lint commands; fix any findings; commit if needed.
+- [ ] Milestone 4: Push, open a draft PR, and drive preflight to `CLEAN` (CI green on the pushed head).
+
+## Surprises & Discoveries
+
+(Add entries as work proceeds.)
+
+- Observation: …
+  Evidence: …
+
+## Decision Log
+
+(Add entries as you go.)
+
+- Decision: …
+  Rationale: …
+  Date/Author: …
+
+## Outcomes & Retrospective
+
+(Summarize at completion or major milestones.)
+
+## Context and Orientation
+
+The docs site is built from MDX under `docs/`. CLI release history is one file, `docs/changelog/cli.mdx`, newest-first: each version is a `# vX.Y.Z` heading, then an italic date, an optional one-paragraph summary, category sections, and a `---` separator. Navigation is already wired — `docs/docs.json` lists `"changelog/cli"` under the Changelog product. Do not add a new page or a `docs.json` entry. MDX here means Markdown plus JSX components such as `<Dropdown>`.
+
+**Latest documented version.** `docs/changelog/cli.mdx` opens at `# v0.11.0` dated *August 12, 2026*. That entry matches the `mirurobotics/cli` `v0.11.0` release notes (file-rule rename, instance slots, richer schema-push errors, schema-identity fix). Do not edit it.
+
+**Latest shipped version (verified 2026-08-27).** `gh release list -R mirurobotics/cli` shows `v0.11.0` as `Latest` (stable) and `v0.11.1-beta.10` as the newest tag (`publishedAt` `2026-08-27T23:41:24Z`). There is no stable `v0.11.1` tag. This repo never publishes beta suffixes in changelog headings (`# v0.10.3`, `# v0.11.0`, …). The install transcript already says `Version: 0.11.1` (`docs/developers/cli/install.mdx`, `docs/references/cli/version.mdx`). Write `# v0.11.1`.
+
+**Source of truth, in this order.**
+
+1. `gh release view <tag> -R mirurobotics/cli` — what was packaged.
+2. `git -C /home/ben/miru/workbench1/repos/cli-private log v0.11.0..origin/main --oneline` — commit messages. Local tags in `cli-private` may lag GitHub (they stopped at `v0.11.1-beta.4` on 2026-08-27); prefer `origin/main` and the GitHub notes.
+3. Existing CLI Reference pages in this repo — command names, flags, and link targets that already shipped.
+
+**User-facing delta `v0.11.0` → current `v0.11.1` line.** At `v0.11.0` the root command registered `login`, `version`, hidden `env`, and `release`. `miru login` printed a dashboard URL and waited for a pasted token. `miru version` printed only `Version` / `Commit` / `Built`.
+
+New commands (all already documented; link them, do not re-describe the full reference):
+
+- `miru device clone` — `/references/cli/device-clone`
+- `miru device stage` — `/references/cli/device-stage` (positional device name, `--release`, optional `--root` / `--description`)
+- `miru deployment clone` — `/references/cli/deployment-clone`
+- `miru schema validate` — `/references/cli/schema-validate`
+- `miru whoami` — `/references/cli/whoami`
+
+Other user-facing changes:
+
+- `miru login` is now the OAuth device-authorization flow. It opens the verification URL (`--no-browser` prints it). Paste-token login is gone. Stored tokens and `MIRU_API_KEY` still work. See `docs/snippets/references/cli/login/examples.mdx`.
+- `MIRU_HOME` overrides the state directory (default `$HOME/.miru`). The directory must already exist. Not yet mentioned elsewhere in this repo; the changelog is the first mention and must not invent extra semantics.
+- `miru version` adds a `Miru CLI` header plus `Go` and `OS/Arch`.
+- Clone and stage print config files as one tree.
+- Ownership: the CLI will not create state in a directory this user does not own; under `sudo` it keeps the caller's state when `MIRU_HOME` / `HOME` point at it.
+- Fixes: login could miss a browser approval before the first poll; `miru whoami` now expands API-key scopes; permission-denied / read-only clone destinations and unreachable stage slot files are named as such.
+
+**Do not document (internal or beta-only churn).** API client plumbing (`feat(api): *`). Hidden `miru env`. Test / build / chore / dependency commits. Intra-beta `miru deployment stage` and the short-lived `--device` flag — they never shipped in a stable release; the public command is `miru device stage {device-name}`. Transcript polish (dim `<root>`, abbreviated deployment id). Whoami capitalization / dropped opaque ids (shape of a new command, not a separate bullet).
+
+**House style.** Copy the v0.11.0 block in the same file: untouched frontmatter and `Dropdown` import; `#` version heading; italic date; one-paragraph summary; then only the non-empty subset of `## Breaking changes`, `## Features`, `## Improvements`, `## Fixes` (that order); hyphen bullets with no trailing period; `<Dropdown>` for a breaking interaction that needs explanation; flag names in backticks (the `no-double-dash` linter rejects `--` in prose); em dash (`—`) in prose; trailing `---` before the old `# v0.11.0` section. Sentence-case headings — the `heading-case` linter allows version tags and the tokens `CLI` / `API`. Link only to pages that exist. `docs/changelog/product.mdx` is out of scope.
+
+**Lint and CI.** From `docs/`: `./scripts/lint.sh` runs the Go MDX linter, ESLint MDX, CSpell, and the OpenAPI check. `./scripts/preflight.sh` runs `pnpm run test:lint`, the Go lint + coverage gate for `tools/lint`, `./scripts/lint.sh`, `./scripts/audit.sh`, and bats. `.github/workflows/ci.yml` adds `pnpm run validate` (`mint validate`) on the `lint` job. CSpell's allowlist is `cspell.json`; add a word only if lint reports it, in sorted position. **`CLEAN`** in this plan means every GitHub Actions check on the pushed branch head is green.
+
+## Plan of Work
+
+Edit only `docs/changelog/cli.mdx`. Insert the new section immediately after the import block (the blank line after `import { Dropdown } …`) and before `# v0.11.0`. Do not change frontmatter, the import, or any existing version section.
+
+At implementation time, re-run the verification commands in Milestone 1. If a stable `v0.11.1` release exists, use its `publishedAt` date. If only `v0.11.1-beta.*` tags exist, keep the heading `# v0.11.1` and date the entry from the newest `v0.11.1*` release's UTC calendar day (for beta.10 that is *August 27, 2026*). If commits landed after this plan that add another user-facing command or remove one listed below, update the bullets to match the sources — do not invent.
+
+Use this entry unless Milestone 1 contradicts it. Indentation in the file is column 0 (not nested in another component).
+
+    # v0.11.1
+
+    *August 27, 2026*
+
+    CLI `v0.11.1` adds commands for cloning and staging device configs, validating a schema without creating a release, and showing the authenticated principal. Interactive login now uses the OAuth device authorization flow instead of pasting a dashboard token.
+
+    ## Breaking changes
+
+    <Dropdown title="Interactive login">
+
+    `miru login` no longer prompts you to paste a token from the dashboard. It opens a verification URL in your browser and waits until you approve access. On SSH sessions or headless machines, pass `--no-browser` to print the URL instead of opening it.
+
+    Stored tokens from earlier logins and `MIRU_API_KEY` authentication are unchanged.
+
+    </Dropdown>
+
+    ## Features
+
+    - Add [`miru device clone`](/references/cli/device-clone) to write a device's current deployment configs onto disk
+    - Add [`miru device stage`](/references/cli/device-stage) to stage a deployment from local config files
+    - Add [`miru deployment clone`](/references/cli/deployment-clone) to write a specific deployment's configs onto disk
+    - Add [`miru schema validate`](/references/cli/schema-validate) to check a schema against the same server rules as `miru release create` without creating anything
+    - Add [`miru whoami`](/references/cli/whoami) to show the authenticated principal and workspace
+    - Add the `MIRU_HOME` environment variable to override the CLI state directory (defaults to `~/.miru`)
+
+    ## Improvements
+
+    - `miru version` now prints a `Miru CLI` header plus `Go` and `OS/Arch` lines
+    - Clone and stage transcripts render config files as a single tree
+    - Refuse to create CLI state under a directory this user does not own, and report the resolved credentials path
+
+    ## Fixes
+
+    - Fix a race where `miru login` could miss a browser approval before the first poll
+    - Show API key scopes on `miru whoami`
+    - Report a permission-denied or read-only clone destination as such, and an unreachable stage slot file as unreachable rather than missing
+
+    ---
+
+If CSpell flags a word in the new text, add it to `cspell.json` `words` in sorted order and commit it with the changelog. No other files.
+
+## Concrete Steps
+
+### Milestone 1 — Re-verify sources
+
+From any directory:
+
+    gh release list -R mirurobotics/cli --limit 15
+
+Expect the newest tag to be a `v0.11.1*` release (prerelease or stable) and `v0.11.0` to remain the previous stable. Then:
+
+    gh release view v0.11.1 -R mirurobotics/cli
+    gh release view v0.11.1-beta.10 -R mirurobotics/cli
+
+The first command fails if the stable tag does not exist; that is expected until it is cut. Use the newest existing `v0.11.1*` view for the Features / Fixes list.
+
+From `/home/ben/miru/workbench1/repos/cli-private`:
+
+    git fetch origin --tags
+    git log v0.11.0..origin/main --oneline --no-merges
+
+Confirm every Features / Breaking / Fixes bullet still maps to a user-facing commit, and that no new user-facing command appeared.
+
+From `/home/ben/miru/workbench1/repos/docs`:
+
+    git branch --show-current
+    git status --short
+
+Expect `docs/cli-latest-changelog` and a clean tree (this plan file may already be committed or uncommitted; do not create a second branch).
+
+No commit in this milestone unless you only record a source correction in this plan's living sections.
+
+### Milestone 2 — Insert the entry and commit
+
+From `/home/ben/miru/workbench1/repos/docs`, insert the block from Plan of Work. Then:
+
+    grep -n "^# " docs/changelog/cli.mdx
+
+Expect `v0.11.1` first, then `v0.11.0`, `v0.10.3`, … with no duplicate `v0.11.1`.
+
+    git diff --stat
+
+Expect only `docs/changelog/cli.mdx` (insertions only) unless CSpell required an edit.
+
+    git add docs/changelog/cli.mdx
+    git commit -m "$(cat <<'EOF'
+    docs(changelog): add CLI v0.11.1 release notes
+
+    EOF
+    )"
+
+If `cspell.json` changed, stage it in the same commit. One commit for this milestone.
+
+### Milestone 3 — Test and lint
+
+From `/home/ben/miru/workbench1/repos/docs` (run `pnpm install` first if `node_modules/` is missing):
+
+    pnpm run test:lint
+    ./scripts/lint.sh
+    pnpm run validate
+
+Expect: lint smoke tests pass; `./scripts/lint.sh` prints that documentation lint checks passed and CSpell reports 0 issues; `pnpm run validate` prints that build validation passed. These are the repo's tests for MDX prose — there is no changelog unit test. If a check fails, fix the entry (or `cspell.json`) and make a **new** commit, then re-run the three commands.
+
+Optional render check: `pnpm dev`, open `/changelog/cli`, confirm the v0.11.1 heading, date, dropdown, and in-page links.
+
+### Milestone 4 — Publish and preflight
+
+From `/home/ben/miru/workbench1/repos/docs`:
+
+    git fetch origin main
+    git rebase origin/main
+    git push -u origin HEAD
+
+If the rebase rewrote commits that were already on the remote, `git push --force-with-lease` is required; that is the expected follow-up, not a destructive reset. Then, if no PR exists:
+
+    gh pr create --draft --base main --title "docs(changelog): add CLI v0.11.1 release notes" --body "$(cat <<'EOF'
+    ## Summary
+    - Add the `# v0.11.1` section to `docs/changelog/cli.mdx` for user-facing CLI changes since `v0.11.0`.
+
+    ## Test plan
+    - [ ] `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` exit 0
+    - [ ] `/changelog/cli` opens with `# v0.11.1` and the v0.11.0 section is unchanged
+    - [ ] Preflight reports CLEAN (CI green on this head)
+
+    EOF
+    )"
+
+Watch CI on the current head:
+
+    git rev-parse HEAD
+    gh pr checks --watch
+
+If any check is red, fetch the failed logs (`gh run view <id> --log-failed`), fix, **new** commit, push once, and watch again. Repeat until every check is green for that head SHA.
+
+Preflight must report `CLEAN` (CI green on the pushed branch head) before the PR leaves draft and before this task is reported complete. A green local `./scripts/preflight.sh` is useful but not sufficient. A green run on an older commit is not sufficient.
+
+## Validation and Acceptance
+
+1. `docs/changelog/cli.mdx` starts its body (after frontmatter + import) with `# v0.11.1`, an italic date, a one-paragraph summary, then only the non-empty subset of `## Breaking changes` / `## Features` / `## Improvements` / `## Fixes`, then `---`, then the untouched `# v0.11.0` section.
+2. Every Features bullet names a command or env var that exists in `mirurobotics/cli` release notes or `cli-private` history since `v0.11.0`, and every command link target exists under `docs/references/cli/`.
+3. No bullet describes `miru deployment stage`, a positional-to-`--device` rename, hidden `miru env`, or API-client internals.
+4. `grep -n "^# " docs/changelog/cli.mdx` lists `v0.11.1` then `v0.11.0` then older versions, each once.
+5. `git diff main -- docs/changelog/cli.mdx` is a pure insertion at the top of the body (plus a `cspell.json` words-only edit if lint required it). No other path in the diff.
+6. `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` all exit 0.
+7. **Preflight reports `CLEAN`.** `gh pr checks` shows every GitHub Actions check passing for the current pushed head SHA. Local `pnpm run test:lint` / `./scripts/lint.sh` / `pnpm run validate` (criterion 6) plus this CI-green head must both hold before the PR leaves draft and before this task is reported complete.
+
+## Idempotence and Recovery
+
+Inserting the section is a text edit. Re-running Milestone 2 on a tree that already has `# v0.11.1` at the top is a no-op if the content matches; if it drifted, replace only that section. `git revert` of the Milestone 2 commit restores the pre-change file. Lint commands are read-only aside from building `tools/lint/lint` (gitignored). If CI fails after a push, fix the cause and add a new commit — do not amend a pushed commit. The only force-push this plan allows is `--force-with-lease` after rebasing onto `origin/main`.

--- a/plans/completed/20260827-cli-v0.11.1-changelog.md
+++ b/plans/completed/20260827-cli-v0.11.1-changelog.md
@@ -49,6 +49,7 @@ The public CLI changelog at `/changelog/cli` still opens with `# v0.11.0` (*Augu
 - Step 2 refine: 39-line single-file changelog (plan excluded) exceeded the <30-line fast path. Review: no findings. No refine commit.
 - Milestone 3 / tests: adjusted test plan is no new files. `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` all exited 0. CSpell 0 issues. No `cspell.json` change.
 - Milestone 4: Draft PR https://github.com/mirurobotics/docs/pull/171. First CI head `58bcaca` — lint, audit, changes, shell-tests passed (Mintlify Deployment / [code]smith skipped). Preflight `CLEAN`.
+- Implementation complete. Plan moved to `plans/completed/`. Delivery re-check and mark-ready are the remaining `$task` steps.
 
 ## Context and Orientation
 


### PR DESCRIPTION
## Summary
- Add the `# v0.11.1` section to the CLI changelog for user-facing changes since `v0.11.0` (clone/stage, schema validate, whoami, OAuth login, `MIRU_HOME`).
- Drop the unshipped credentials-path claim so the ownership improvement matches current CLI output.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790473644&installation_model_id=425273&pr_number=171&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F171&signature=0e65aef0ae19862488273861ead7e28d1e320dd00c30b6c1f88bbe2ed9cdbc7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->