### PR TITLE
docs: add Ansible as a device provisioning method

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "USERGROUPS",
     "WIF",
     "affordances",
+    "ansible",
     "chgrp",
     "cooldown",
     "costmap",

--- a/docs/cfg-mgmt/provision-devices/ansible.mdx
+++ b/docs/cfg-mgmt/provision-devices/ansible.mdx
@@ -1,0 +1,68 @@
+---
+title: "Ansible"
+---
+
+import { Framed } from '/snippets/components/framed.jsx';
+
+<Framed
+  background="https://assets.mirurobotics.com/docs/v04/images/devices/background.jpeg"
+  image="https://assets.mirurobotics.com/docs/v04/images/devices/provisioning/header:create-token.png"
+  innerRadius="8px"
+  outerRadius="12px"
+  borderWidth="42px 38px 42px 38px"
+/>
+
+The [`mirurobotics.agent`](https://github.com/mirurobotics/ansible-collection-agent) Ansible collection installs the Miru Agent and provisions every host in your play. It is the [provisioning-token](/cfg-mgmt/provision-devices/provisioning-tokens) flow packaged as a role: the API key stays on the Ansible controller, and only a short-lived token reaches each device.
+
+The collection requires Miru Agent `v0.10.2` or later (`provision --check` is not in earlier releases).
+
+<Note>
+  The collection is not on Ansible Galaxy yet. Install it from the public GitHub repository.
+</Note>
+
+## Install the collection
+
+On the Ansible controller (ansible-core 2.15 or later):
+
+```yaml
+# requirements.yml
+collections:
+  - name: https://github.com/mirurobotics/ansible-collection-agent.git
+    type: git
+    version: main
+```
+
+```bash
+ansible-galaxy collection install -r requirements.yml
+```
+
+## Create an API key
+
+The role mints a provisioning token on the controller. Create an [API key](/admin/apikeys#create-an-api-key) with the `devices:provision` and `provisioning_tokens:write` scopes, and store it in [Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html) or your CI secret store. The key is never written to managed devices.
+
+## Run the role
+
+```yaml
+- name: Provision Miru devices
+  hosts: robots
+  roles:
+    - role: mirurobotics.agent.provision
+      vars:
+        miru_api_key: "{{ vault_miru_api_key }}"
+        miru_agent_version: "0.10.2-beta.1"
+        miru_agent_deb_url: "https://github.com/mirurobotics/agent/releases/download/v0.10.2-beta.1/miru-agent_0.10.2-beta.1_{{ miru_apt_architecture }}.deb"
+```
+
+`miru_agent_version` is required and must be `0.10.2` or later. Use `latest` only when you want the newest package on every run.
+
+<Warning>
+  Apt `stable` does not yet publish `0.10.2`. Until it does, set `miru_agent_deb_url` to the matching GitHub `.deb` (the URL above substitutes `amd64` or `arm64`). Drop `miru_agent_deb_url` once you can pin `miru_agent_version: "0.10.2"` from apt.
+</Warning>
+
+The role is idempotent. Already-provisioned hosts are detected with `miru-agent provision --check` and skipped. A ready-made playbook is included: `ansible-playbook -i inventory mirurobotics.agent.provision` targets the `robots` group.
+
+## Verify
+
+The role confirms the `miru` systemd service is active on each host. To confirm the control-plane side, open the [Devices page](https://app.mirurobotics.com/devices) — new devices transition `Activating` → `Online` within seconds.
+
+Reprovisioning (reassociating a machine with an existing Miru device) remains a [dashboard-only flow](/cfg-mgmt/provision-devices/reprovision).

--- a/docs/cfg-mgmt/provision-devices/ansible.mdx
+++ b/docs/cfg-mgmt/provision-devices/ansible.mdx
@@ -49,15 +49,10 @@ The role mints a provisioning token on the controller. Create an [API key](/admi
     - role: mirurobotics.agent.provision
       vars:
         miru_api_key: "{{ vault_miru_api_key }}"
-        miru_agent_version: "0.10.2-beta.1"
-        miru_agent_deb_url: "https://github.com/mirurobotics/agent/releases/download/v0.10.2-beta.1/miru-agent_0.10.2-beta.1_{{ miru_apt_architecture }}.deb"
+        miru_agent_version: "0.10.2"
 ```
 
 `miru_agent_version` is required and must be `0.10.2` or later. Use `latest` only when you want the newest package on every run.
-
-<Warning>
-  Apt `stable` does not yet publish `0.10.2`. Until it does, set `miru_agent_deb_url` to the matching GitHub `.deb` (the URL above substitutes `amd64` or `arm64`). Drop `miru_agent_deb_url` once you can pin `miru_agent_version: "0.10.2"` from apt.
-</Warning>
 
 The role is idempotent. Already-provisioned hosts are detected with `miru-agent provision --check` and skipped. A ready-made playbook is included: `ansible-playbook -i inventory mirurobotics.agent.provision` targets the `robots` group.
 

--- a/docs/cfg-mgmt/provision-devices/overview.mdx
+++ b/docs/cfg-mgmt/provision-devices/overview.mdx
@@ -10,13 +10,15 @@ Provisioning a device is the process of creating a device in Miru and registerin
 
 ## Methods
 
-There are three methods for provisioning a device:
+There are four methods for provisioning a device:
 
 1. [Dashboard](/cfg-mgmt/provision-devices/dashboard) - a manual method for provisioning devices one at a time via the Miru web interface; great for getting started or managing individual devices.
 
-2. [Provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens) - a programmatic method for securely provisioning devices at scale; great for automated provisioning or integrating with existing infrastructure management tools and workflows.
+2. [Ansible](/cfg-mgmt/provision-devices/ansible) - install the agent and provision a fleet with the `mirurobotics.agent` collection; great for teams that already manage devices with Ansible.
 
-3. [Provisioning script](/cfg-mgmt/provision-devices/provisioning-script) - the legacy method for programmatically provisioning devices; unsupported with Miru Agent [v0.9.0](/changelog/agent) or later.
+3. [Provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens) - a programmatic method for securely provisioning devices at scale; great for automated provisioning or integrating with existing infrastructure management tools and workflows.
+
+4. [Provisioning script](/cfg-mgmt/provision-devices/provisioning-script) - the legacy method for programmatically provisioning devices; unsupported with Miru Agent [v0.9.0](/changelog/agent) or later.
 
 ## Miru Agent installation
 
@@ -24,7 +26,7 @@ No matter which method you choose, the device requires the `miru-agent` package 
 
 If you're having trouble downloading the `miru-agent` package to your device, refer to the [poor connectivity](/developers/agent/install#poor-connectivity) documentation for a workaround.
 
-Once you've installed the `miru-agent` package, proceed with the provisioning process via the [dashboard](/cfg-mgmt/provision-devices/dashboard) or [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens).
+Once you've installed the `miru-agent` package, proceed with the provisioning process via the [dashboard](/cfg-mgmt/provision-devices/dashboard), [Ansible](/cfg-mgmt/provision-devices/ansible), or [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens). The Ansible collection installs the package for you.
 
 ## Reprovisioning
 

--- a/docs/cfg-mgmt/provision-devices/provisioning-tokens.mdx
+++ b/docs/cfg-mgmt/provision-devices/provisioning-tokens.mdx
@@ -16,7 +16,7 @@ import CmdBreakdown from '/snippets/devices/provision/provision-cmd-breakdown.md
   borderWidth="42px 38px 42px 38px"
 />
 
-To programmatically provision devices, Miru offers provisioning tokens.
+To programmatically provision devices, Miru offers provisioning tokens. If you already manage hosts with Ansible, use the [`mirurobotics.agent` collection](/cfg-mgmt/provision-devices/ansible) instead of minting tokens yourself.
 
 Provisioning tokens are only supported when installing `miru-agent` version `v0.9.0` or later. If installing a version that precedes `v0.9.0`, continue to use the [provisioning script](/cfg-mgmt/provision-devices/provisioning-script).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,6 +78,7 @@
                 "pages": [
                   "cfg-mgmt/provision-devices/overview",
                   "cfg-mgmt/provision-devices/dashboard",
+                  "cfg-mgmt/provision-devices/ansible",
                   "cfg-mgmt/provision-devices/provisioning-tokens",
                   "cfg-mgmt/provision-devices/provisioning-script",
                   "cfg-mgmt/provision-devices/reprovision"

--- a/docs/getting-started/quick-start/provision-device.mdx
+++ b/docs/getting-started/quick-start/provision-device.mdx
@@ -12,7 +12,7 @@ Before deploying config instances, we must provision a device with your workspac
 
 The Miru Agent is a lightweight `systemd` service that runs on your machines, handling the deployment lifecycle of configurations. For more information on the agent, visit the [Miru Agent](/developers/agent/overview) section.
 
-This getting started guide demonstrates the [dashboard](/cfg-mgmt/provision-devices/dashboard). However, you can also use [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens) to provision devices programmatically.
+This getting started guide demonstrates the [dashboard](/cfg-mgmt/provision-devices/dashboard). You can also provision devices with [Ansible](/cfg-mgmt/provision-devices/ansible) or [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens).
 
 ## Supported platforms
 


### PR DESCRIPTION
## Summary
- Add an Ansible provisioning guide that installs `mirurobotics.agent` from the public GitHub repo (Galaxy namespace is still pending).
- List Ansible as a fourth provisioning method and point tokens / quick start at it.
- Document the GitHub `.deb` workaround until apt publishes agent 0.10.2.

## Test plan
- [ ] `/cfg-mgmt/provision-devices/ansible` renders and is in the Provision devices nav
- [ ] Overview, tokens, and quick-start links resolve
- [ ] Docs lint / cspell accept `ansible`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791304758&installation_model_id=425273&pr_number=177&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F177&signature=457f27073202ad0680668593e6237b99fb61175c9ba89ec15900b44291bd59b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->