### PR TITLE
docs(changelog): add agent v0.10.2 release notes

### DIFF
--- a/docs/changelog/agent.mdx
+++ b/docs/changelog/agent.mdx
@@ -4,6 +4,23 @@ mode: "center"
 description: "Changelog and migration steps for the Miru Agent"
 ---
 
+# v0.10.2
+
+*September 6, 2026*
+
+Miru Agent `v0.10.2` adds `provision --check` so fleet automation can tell whether a device is already provisioned without minting a token, and stops retrying failed retention deletes forever.
+
+## Features
+
+- Added `provision --check` to report whether the device is already provisioned via exit code, without contacting the control plane
+- Retention [file rule](/data-uploads/primitives/file-rules) delete jobs now stop after 10 failed attempts instead of retrying forever, leaving the file on disk
+
+## Fixes
+
+- Fixed a bug where a backward clock step could stall the upload retry queue
+
+---
+
 # v0.10.1
 
 *August 12, 2026*

--- a/plans/active/20260906-agent-v0.10.2-changelog.md
+++ b/plans/active/20260906-agent-v0.10.2-changelog.md
@@ -1,0 +1,231 @@
+# Add the Miru Agent v0.10.2 changelog entry
+
+This ExecPlan is a living document. The sections Progress, Surprises & Discoveries, Decision Log, and Outcomes & Retrospective must be kept up to date as work proceeds.
+
+
+## Scope
+
+| Repository | Access | Description |
+|-----------|--------|-------------|
+| `docs/` (`/home/ben/miru/workbench3/repos/docs`) | read-write | Insert one new version section at the top of `docs/changelog/agent.mdx`. Touch `cspell.json` only if CSpell flags a new word. |
+| `mirurobotics/agent` on GitHub | read-only | Tag `v0.10.2` and the `v0.10.1..v0.10.2` delta. There is no local `agent/` checkout. Do not clone, modify, branch, or commit there. |
+
+This plan lives in `docs/plans/` because the only write is the public agent changelog in this repo.
+
+Working branch: `docs/agent-v0.10.2-changelog` (already created from latest `main`). Do not create another branch. Base branch for the PR: `main`.
+
+
+## Purpose / Big Picture
+
+The public agent changelog at `/changelog/agent` still opens with `# v0.10.1` (*August 12, 2026*). After this change, that page opens with `# v0.10.2` listing only user-facing changes shipped after `v0.10.1`. Use this file's existing categories — Breaking changes, Features, Fixes, Improvements — and omit empty ones. Do not rewrite the existing `# v0.10.1` entry. Do not edit the supported-versions table: `docs/developers/agent/versions.mdx` already has a `v0.10.x` row.
+
+
+## Progress
+
+- [ ] Milestone 1: Re-verify the `v0.10.2` tag and the user-facing delta against the recommended insert.
+- [ ] Milestone 2: Insert the `# v0.10.2` section into `docs/changelog/agent.mdx` and commit.
+- [ ] Milestone 3: Run the docs test/lint commands; fix any findings; commit if needed.
+- [ ] Milestone 4: Push, open a draft PR, and drive preflight to `CLEAN` (CI green on the pushed head).
+
+
+## Surprises & Discoveries
+
+(Add entries as work proceeds.)
+
+
+## Decision Log
+
+(Add entries as work proceeds.)
+
+
+## Outcomes & Retrospective
+
+(Summarize at completion.)
+
+
+## Context and Orientation
+
+The docs site is a Mintlify site. Published content lives under `docs/`. MDX here means Markdown plus JSX. Agent release history is one file, `docs/changelog/agent.mdx`, newest-first. Each version is a `# vX.Y.Z` heading, an italic date, an optional one-paragraph summary, category sections, and a `---` separator. Navigation is already wired: `docs/docs.json` lists `"changelog/agent"` under Changelog. Do not add a page or a `docs.json` entry. This repo has no `AGENTS.md` or `CLAUDE.md`.
+
+**Latest documented version.** `docs/changelog/agent.mdx` opens at `# v0.10.1` dated *August 12, 2026*, with Features (file-rule retention capabilities) and Fixes (shutdown blocking; network errors no longer consume the upload retry budget). Do not repeat those. Changelogs are historical records: do not rewrite existing entries.
+
+**Latest shipped version (verified 2026-09-06).** Annotated tag `v0.10.2` exists on `mirurobotics/agent` (tagger `2026-09-06T21:21:59Z`, commit `db7c20d` `chore: bump version (#228)`). `main` is identical to that tag. There is **no** GitHub Release object for `v0.10.2` yet (`gh release view v0.10.2 -R mirurobotics/agent` returns `release not found`). Latest published Release is still `v0.10.1`. Date the new entry `*September 6, 2026*` from the tag's UTC calendar day. Do not copy the `v0.10.2-beta.1` Release notes; they include lint and refactor commits.
+
+**Source of truth, in this order.**
+
+1. `gh api repos/mirurobotics/agent/git/ref/tags/v0.10.2` and the annotated tag object — confirms the tag exists and its date.
+2. `gh api repos/mirurobotics/agent/compare/v0.10.1...v0.10.2` — 13 commits. Previous stable is `v0.10.1`.
+3. Existing pages on `docs` `main` for link targets only: `docs/data-uploads/primitives/file-rules.mdx` → `/data-uploads/primitives/file-rules`. Do not link `provision --check` at a docs path; `docs/developers/agent/commands.mdx` still says the agent has no CLI, and `docs/cfg-mgmt/provision-devices/provisioning-tokens.mdx` does not document the flag. Documenting the flag on those pages is a separate follow-up (called out on agent PR `#224`) and is out of scope here.
+
+**User-facing** means new or changed commands or flags, operator-visible upload/retention behavior, or breaking behavior. Omit lint/test/chore/deps, version-bump commits, beta tags, and internal refactors.
+
+**User-facing delta `v0.10.1` → `v0.10.2`.** Features and Fixes. No Breaking changes. No Improvements.
+
+Include:
+
+- Features — `provision --check` (`#224`). Offline, read-only, must run as the `miru` user. Exit `0` provisioned (a later `provision` is a no-op), exit `3` not provisioned, exit `1` undetermined (message on stderr). Partial local state counts as not provisioned. Does not call the control plane, so a device that was reprovisioned onto other hardware from the dashboard can still report provisioned locally.
+- Features — retention delete jobs give up after 10 failed attempts (`#211`). Terminal I/O kinds (permission denied, read-only filesystem, path is a directory, and similar) drop immediately. The file is left on disk (fail-open). A later modification of the file can mint a fresh job.
+- Fixes — a backward clock step could leave upload retry deadlines in the future and stall the queue (`#212`). On worker construction, deadlines beyond the backoff horizon are released.
+
+Omit: shared upload/retention queue refactor (`#215`; on-disk JSON unchanged); `feat(lint)` funclen (`#112`); upload test assertions (`#214`); actions/cargo-audit/devcontainer/java-feature chores (`#217`, `#218`, `#219`, `#223`, `#226`); version bumps (`#227`, `#228`).
+
+**House style.** Copy the v0.10.1 block in the same file: leave YAML frontmatter untouched. Then `#` version heading; italic date with a full month name and no ordinal; one-paragraph summary; only the non-empty subset of `## Breaking changes`, `## Features`, `## Fixes`, `## Improvements` in that order; hyphen bullets, sentence case, no trailing period; em dash (`—`, U+2014) in prose, never `--` (the `nodoubledash` linter flags two consecutive hyphens in prose spans; flags such as `--check` must live inside backticks); trailing `---` before the old `# v0.10.1` section; exactly one blank line before and after `---`. Feature voice in this file is `Added …`, not the CLI file's `Add …`.
+
+**Lint and CI.** From `docs/`: `pnpm run test:lint` (→ `./tests/test-lint.sh`); `./scripts/lint.sh` runs the Go MDX linter (`headingcase` allows `# v0.10.2` and `## Features` / `## Fixes`; `nodoubledash` as above), ESLint MDX, CSpell (`cspell.json` at the repo root), and `mint openapi-check`. Validate: `pnpm run validate` (`mint validate`). Preflight: `./scripts/preflight.sh` plus CI. Add a CSpell word only if lint reports it, in sorted position. **`CLEAN`** means every GitHub Actions check on the pushed branch head is green. Local preflight is useful but not sufficient.
+
+
+## Plan of Work
+
+Edit only `docs/changelog/agent.mdx`. Insert the new section immediately after the frontmatter's closing `---` and its following blank line, and immediately before `# v0.10.1`. Do not change frontmatter or any existing version section.
+
+At implementation time, re-run the verification commands in Milestone 1. If sources still match, use the insert below. If they contradict it, update the bullets to match the sources — do not invent.
+
+Use this entry unless Milestone 1 contradicts it. Indentation in the file is column 0.
+
+    # v0.10.2
+
+    *September 6, 2026*
+
+    Miru Agent `v0.10.2` adds `provision --check` so fleet automation can tell whether a device is already provisioned without minting a token, and stops retrying failed retention deletes forever.
+
+    ## Features
+
+    - Added `provision --check` to report whether the device is already provisioned via exit code, without contacting the control plane
+    - Retention [file rule](/data-uploads/primitives/file-rules) delete jobs now stop after 10 failed attempts instead of retrying forever, leaving the file on disk
+
+    ## Fixes
+
+    - Fixed a bug where a backward clock step could stall the upload retry queue
+
+    ---
+
+The first Features bullet is `#224`. The second is `#211`. The Fixes bullet is `#212`. Keep `--check` inside backticks in both the summary and the bullet so `nodoubledash` stays clean.
+
+If CSpell flags a word in the new text, add it to `cspell.json` `words` in sorted order and commit it with the changelog. No other files.
+
+
+## Concrete Steps
+
+### Milestone 1 — Re-verify sources
+
+From any directory:
+
+    gh release list -R mirurobotics/agent --limit 10
+    gh api repos/mirurobotics/agent/git/ref/tags/v0.10.2
+    gh api repos/mirurobotics/agent/compare/v0.10.1...v0.10.2 --jq '{ahead_by, commits: [.commits[] | .commit.message | split("\n")[0]]}'
+
+Expect the `v0.10.2` tag to exist. Expect the compare to still be 13 commits whose user-facing set is `#224`, `#211`, and `#212`. A GitHub Release for `v0.10.2` may or may not exist yet; its absence is not a blocker when the tag exists. If a Release exists, do not copy its notes verbatim.
+
+From `/home/ben/miru/workbench3/repos/docs`:
+
+    git branch --show-current
+    git status --short
+    grep -c '^# v0.10.2' docs/changelog/agent.mdx
+    grep -c 'v0.10.x' docs/developers/agent/versions.mdx
+
+Expect `docs/agent-v0.10.2-changelog` and a clean tree (this plan file may already be committed or uncommitted; do not create a second branch). Expect `0` for the changelog heading (not yet inserted) and `1` for the versions-table row (already present — do not add another).
+
+Commit step: if sources still match, skip the commit. If they contradict the recommended insert, update this plan's living sections and Plan of Work, then from `/home/ben/miru/workbench3/repos/docs`:
+
+    git add plans/backlog/20260906-agent-v0.10.2-changelog.md
+    git commit -m "$(cat <<'EOF'
+    docs(plan): correct agent v0.10.2 changelog sources
+
+    EOF
+    )"
+
+One commit for this milestone, and only if the plan itself needed a source correction.
+
+
+### Milestone 2 — Insert the entry and commit
+
+From `/home/ben/miru/workbench3/repos/docs`, insert the block from Plan of Work. Then:
+
+    grep -n "^# " docs/changelog/agent.mdx
+
+Expect `v0.10.2` first, then `v0.10.1`, `v0.10.0`, … with no duplicate `v0.10.2`.
+
+    git diff --stat
+
+Expect only `docs/changelog/agent.mdx` (insertions only) unless CSpell required an edit.
+
+    git add docs/changelog/agent.mdx
+    git commit -m "$(cat <<'EOF'
+    docs(changelog): add agent v0.10.2 release notes
+
+    EOF
+    )"
+
+If `cspell.json` changed, stage it in the same commit. One commit for this milestone.
+
+
+### Milestone 3 — Test and lint
+
+From `/home/ben/miru/workbench3/repos/docs` (run `pnpm install --frozen-lockfile` first if `node_modules/` is missing):
+
+    pnpm run test:lint
+    ./scripts/lint.sh
+    pnpm run validate
+
+Expect: lint smoke tests pass (silent on success, exit 0); `./scripts/lint.sh` prints `All documentation lint checks passed.` and CSpell reports 0 issues; `pnpm run validate` prints that build validation passed. These are the repo's tests for MDX prose — there is no changelog unit test. If a check fails, fix the entry (or `cspell.json`) and make a **new** commit, then re-run the three commands.
+
+Commit step: if all three commands exit 0 with no file changes, skip the commit. If a fix was required, from `/home/ben/miru/workbench3/repos/docs`:
+
+    git add docs/changelog/agent.mdx
+    git commit -m "$(cat <<'EOF'
+    docs(changelog): fix agent v0.10.2 lint findings
+
+    EOF
+    )"
+
+Stage `cspell.json` in that same commit if it changed. One commit for this milestone, and only if a fix was needed.
+
+
+### Milestone 4 — Publish and preflight
+
+From `/home/ben/miru/workbench3/repos/docs`:
+
+    git fetch origin main
+    git rebase origin/main
+    git push -u origin HEAD
+
+If the rebase rewrote commits that were already on the remote, `git push --force-with-lease` is required; that is the expected follow-up, not a destructive reset. Then, if no PR exists:
+
+    gh pr create --draft --base main --title "docs(changelog): add agent v0.10.2 release notes" --body "$(cat <<'EOF'
+    ## Summary
+    - Add the `# v0.10.2` section to `docs/changelog/agent.mdx` for user-facing agent changes since `v0.10.1`.
+
+    ## Test plan
+    - [ ] `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` exit 0
+    - [ ] `/changelog/agent` opens with `# v0.10.2` and the v0.10.1 section is unchanged
+    - [ ] Preflight reports CLEAN (CI green on this head)
+
+    EOF
+    )"
+
+Watch CI on the current head:
+
+    git rev-parse HEAD
+    gh pr checks --watch
+
+If any check is red, fetch the failed logs (`gh run view <id> --log-failed`), fix, **new** commit, push once, and watch again. Repeat until every check is green for that head SHA.
+
+Commit step: if CI is green on the first pushed head, skip the commit. If a CI fix was required, from `/home/ben/miru/workbench3/repos/docs` commit only the fix (one commit), push, and re-watch.
+
+Preflight must report `CLEAN` (CI green on the pushed branch head) before the PR leaves draft and before this task is reported complete. A green local `./scripts/preflight.sh` is useful but not sufficient. A green run on an older commit is not sufficient.
+
+
+## Validation and Acceptance
+
+1. `docs/changelog/agent.mdx` starts its body (after frontmatter) with `# v0.10.2`, `*September 6, 2026*`, a one-paragraph summary, `## Features` then `## Fixes` only (no empty Breaking / Improvements headings), then `---`, then the untouched `# v0.10.1` section.
+2. The Features bullets cover `provision --check` and the 10-attempt retention give-up only. The Fixes bullet covers the backward-clock upload-queue stall only. `--check` appears only inside backticks.
+3. No bullet repeats a v0.10.1 item, documents the shared-queue refactor, or treats lint/deps/test commits as user-facing.
+4. `grep -n "^# " docs/changelog/agent.mdx` lists `v0.10.2` then `v0.10.1` then older versions, each once.
+5. `git diff main -- docs/changelog/agent.mdx` is a pure insertion at the top of the body (plus a `cspell.json` words-only edit if lint required it). No other path in the diff, including `docs/developers/agent/versions.mdx` and `docs/docs.json`.
+6. From `/home/ben/miru/workbench3/repos/docs`, `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` all exit 0.
+7. **Preflight reports `CLEAN`.** `gh pr checks` shows every GitHub Actions check passing for the current pushed head SHA. Local `pnpm run test:lint` / `./scripts/lint.sh` / `pnpm run validate` (criterion 6) plus this CI-green head must both hold before the PR leaves draft and before this task is reported complete.
+
+
+## Idempotence and Recovery
+
+Inserting the section is a text edit. The `grep -c '^# v0.10.2'` guard returns `0` before the edit and `1` after; if it already returns `1` and the content matches Plan of Work, skip Milestone 2 rather than pasting a duplicate. `git revert` of the Milestone 2 commit restores the pre-change file. Lint commands are read-only aside from building `tools/lint/lint` (gitignored). If CI fails after a push, fix the cause and add a new commit — do not amend a pushed commit. The only force-push this plan allows is `--force-with-lease` after rebasing onto `origin/main`. The agent repo is never written to.

--- a/plans/completed/20260906-agent-v0.10.2-changelog.md
+++ b/plans/completed/20260906-agent-v0.10.2-changelog.md
@@ -22,25 +22,25 @@ The public agent changelog at `/changelog/agent` still opens with `# v0.10.1` (*
 
 ## Progress
 
-- [ ] Milestone 1: Re-verify the `v0.10.2` tag and the user-facing delta against the recommended insert.
-- [ ] Milestone 2: Insert the `# v0.10.2` section into `docs/changelog/agent.mdx` and commit.
-- [ ] Milestone 3: Run the docs test/lint commands; fix any findings; commit if needed.
-- [ ] Milestone 4: Push, open a draft PR, and drive preflight to `CLEAN` (CI green on the pushed head).
+- [x] (2026-09-06) Milestone 1: Re-verified `v0.10.2` tag and `v0.10.1...v0.10.2` delta (13 commits; user-facing `#224`, `#211`, `#212`). Insert unchanged.
+- [x] (2026-09-06) Milestone 2: Inserted `# v0.10.2` into `docs/changelog/agent.mdx` (`650f63d`).
+- [x] (2026-09-06) Milestone 3: `pnpm run test:lint`, `./scripts/lint.sh`, and `pnpm run validate` exited 0. No CSpell or lint fixes.
+- [x] (2026-09-06) Milestone 4: Draft PR #180. Preflight `CLEAN` on `650f63d`.
 
 
 ## Surprises & Discoveries
 
-(Add entries as work proceeds.)
+- Observation: No GitHub Release object for `v0.10.2` at implementation time. Dated from the annotated tag (`2026-09-06T21:21:59Z`).
 
 
 ## Decision Log
 
-(Add entries as work proceeds.)
+- Decision: Keep the plan insert unchanged. / Rationale: Source re-check matched `#224`, `#211`, `#212`. / Date/Author: 2026-09-06, implementer.
 
 
 ## Outcomes & Retrospective
 
-(Summarize at completion.)
+Shipped `# v0.10.2` on `/changelog/agent` (Features: `provision --check`, 10-attempt retention give-up; Fixes: backward-clock upload-queue stall). Versions table and `docs.json` untouched. Draft PR https://github.com/mirurobotics/docs/pull/180. Preflight `CLEAN` on `650f63d`.
 
 
 ## Context and Orientation


### PR DESCRIPTION
## Summary
- Publish agent v0.10.2 changelog notes covering `provision --check`, a 10-attempt cap on failed retention deletes, and a clock-step fix for the upload retry queue.
- Close out the ExecPlan that tracked this changelog update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791322063&installation_model_id=425273&pr_number=180&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F180&signature=5fbc7a14b358e0076235f164a96947024af64201121ed52ef3f7d8022437c4d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->