### PR TITLE
docs(provision): install the Ansible collection from Galaxy

### DIFF
--- a/docs/cfg-mgmt/provision-devices/ansible.mdx
+++ b/docs/cfg-mgmt/provision-devices/ansible.mdx
@@ -4,7 +4,7 @@ title: "Ansible"
 
 import Verify from '/snippets/agent/install/verify.mdx';
 
-If you already manage hosts with Ansible, use the official [Ansible collection](https://github.com/mirurobotics/ansible-collection-agent) instead of minting [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens) yourself. One play installs the agent and registers each host.
+If you already manage hosts with Ansible, use the official [`mirurobotics.agent`](https://galaxy.ansible.com/ui/repo/published/mirurobotics/agent/) collection instead of minting [provisioning tokens](/cfg-mgmt/provision-devices/provisioning-tokens) yourself. One play installs the agent and registers each host.
 
 ## What it does
 
@@ -24,22 +24,25 @@ The `miru_device_name` is used to match the device in Miru. If a device with tha
 
 ## Install the collection
 
-The collection is available on [GitHub](https://github.com/mirurobotics/ansible-collection-agent/releases). Support for Ansible Galaxy is coming soon.
+Install the collection from [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/mirurobotics/agent/) on the Ansible controller:
 
-Install the collection on the Ansible controller:
+```bash
+ansible-galaxy collection install mirurobotics.agent
+```
+
+Or pin a version in `requirements.yml`:
 
 ```yaml requirements.yml
 collections:
-  - name: https://github.com/mirurobotics/ansible-collection-agent.git
-    type: git
-    version: main
+  - name: mirurobotics.agent
+    version: ">=0.1.2"
 ```
 
 ```bash
 ansible-galaxy collection install -r requirements.yml
 ```
 
-You can also install a [release tarball](https://github.com/mirurobotics/ansible-collection-agent/releases).
+You can also install from [git](https://github.com/mirurobotics/ansible-collection-agent) or a [GitHub Release tarball](https://github.com/mirurobotics/ansible-collection-agent/releases).
 
 ## Use the role
 


### PR DESCRIPTION
## Summary
- Document Galaxy as the install path for `mirurobotics.agent` now that 0.1.2 is published.
- Keep git and GitHub Release tarball installs as fallbacks.

## Test plan
- [ ] Ansible page install commands match `ansible-galaxy collection install mirurobotics.agent`
- [ ] Galaxy and GitHub fallback links resolve
- [ ] Preview the Ansible provision page


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mirurobotics/codesmith/docs/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791481939&installation_model_id=425273&pr_number=185&repository=mirurobotics%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fmirurobotics%2Fdocs%2Fpull%2F185&signature=dd2be2ec54e58f54e22365fa38a57377f76c7b192fe705a7f54b512d0729d5bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->